### PR TITLE
seeding/refs-to-seed: Add QmYRpzwXkSnCPPNL4b2gn5AFnyyMHFxhS9Nrbau5ycw92H

### DIFF
--- a/seeding/refs-to-seed
+++ b/seeding/refs-to-seed
@@ -30,6 +30,7 @@
 /ipfs/QmTKZgRNwDNZwHtJSjCp6r5FYefzpULfy37JvMt9DwvXse
 /ipfs/QmfYhwKhtkuQkoDbjBShQs89XjKgh4YZKka8ZJN2qQnFFU
 /ipfs/QmQVrrQQxXjf3GESdQc6ajF6TVoNpkszAMMcJLJJczoRJz
+/ipfs/QmYRpzwXkSnCPPNL4b2gn5AFnyyMHFxhS9Nrbau5ycw92H
 
 # docs
 


### PR DESCRIPTION
This is the example filesystem used for my nsinit container demo
(ipfs/container-demos#22).  If/when that PR lands, merging this one
and running make will preserve the example filesystem even when my
IPFS daemon is not online.