### PR TITLE
solarnet: add prometheus on pluto

### DIFF
--- a/solarnet/roles/ipfs_gateway/templates/nginx.conf.j2
+++ b/solarnet/roles/ipfs_gateway/templates/nginx.conf.j2
@@ -26,6 +26,11 @@ server {
         proxy_set_header Host $host;
     }
 
+    location /prometheus {
+        proxy_pass http://127.0.0.1:9090;
+        proxy_set_header Host $host;
+    }
+
     location / {
         proxy_pass http://gateway;
         proxy_set_header Host $host;

--- a/solarnet/roles/prometheus/files/Dockerfile
+++ b/solarnet/roles/prometheus/files/Dockerfile
@@ -1,0 +1,29 @@
+FROM golang:1.4
+MAINTAINER lars@ipfs.io
+
+ENV GOPATH=/go \
+    REPO_PATH=github.com/prometheus/prometheus
+COPY src/ /go/src/$REPO_PATH
+
+RUN cd /go/src/$REPO_PATH \
+    && cp -a ./Godeps/_workspace/src/* "$GOPATH/src/" \
+    && go build -ldflags " \
+            -X main.buildVersion  $(cat version/VERSION) \
+            -X main.buildRevision $(git rev-parse --short HEAD) \
+            -X main.buildBranch   $(git rev-parse --abbrev-ref HEAD) \
+            -X main.buildUser     root \
+            -X main.buildDate     $(date +%Y%m%d-%H:%M:%S) \
+            -X main.goVersion     $(go version | awk '{print substr($3,3)}') \
+        " -o /bin/prometheus $REPO_PATH/cmd/prometheus \
+    && mkdir -p /etc/prometheus /prometheus \
+    && rm -rf /go
+
+EXPOSE     9090
+VOLUME     [ "/prometheus", "/etc/prometheus" ]
+WORKDIR    /prometheus
+ENTRYPOINT [ "/bin/prometheus" ]
+CMD        [ "-config.file=/etc/prometheus/prometheus.yml", \
+             "-storage.local.path=/prometheus", \
+             "-web.path-prefix=/prometheus", \
+             "-web.console.libraries=/etc/prometheus/console_libraries", \
+             "-web.console.templates=/etc/prometheus/consoles" ]

--- a/solarnet/roles/prometheus/meta/main.yml
+++ b/solarnet/roles/prometheus/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+- docker
+- cjdns

--- a/solarnet/roles/prometheus/tasks/main.yml
+++ b/solarnet/roles/prometheus/tasks/main.yml
@@ -1,0 +1,46 @@
+---
+# create/update config
+- file:
+    path: "{{ item }}"
+    state: directory
+  with_items:
+  - /opt/prometheus/config
+  - /opt/prometheus/data
+- template:
+    src: prometheus.yml.j2
+    dest: /opt/prometheus/config/prometheus.yml
+    mode: 0400
+  register: prometheus_yml
+
+# build the docker image, if needed
+- shell: "docker images -a | grep {{ prometheus_ref }}"
+  ignore_errors: true
+  register: prometheus_image_present
+- git:
+    repo: https://github.com/prometheus/prometheus.git
+    dest: /opt/prometheus/src
+    version: "{{ prometheus_ref }}"
+  when: "prometheus_image_present.rc != 0"
+- copy:
+    src: Dockerfile
+    dest: /opt/prometheus/Dockerfile
+  when: "prometheus_image_present.rc != 0"
+- shell: "docker build -t prometheus:{{ prometheus_ref }} /opt/prometheus"
+  when: "prometheus_image_present.rc != 0"
+
+# assert container runs and is up-to-date
+- docker:
+    name: prometheus
+    image: "prometheus:{{ prometheus_ref }}"
+    state: reloaded
+    restart_policy: always
+    net: host
+    volumes:
+    - /opt/prometheus/config:/etc/prometheus
+    - /opt/prometheus/data:/prometheus
+
+# apply config update
+- docker:
+    name: prometheus
+    state: restarted
+  when: "prometheus_yml.changed"

--- a/solarnet/roles/prometheus/templates/prometheus.yml.j2
+++ b/solarnet/roles/prometheus/templates/prometheus.yml.j2
@@ -1,0 +1,27 @@
+---
+global:
+  scrape_interval:     15s # By default, scrape targets every 15 seconds.
+  evaluation_interval: 15s # By default, scrape targets every 15 seconds.
+  # scrape_timeout is set to the global default (10s).
+
+  # Attach these extra labels to all timeseries collected by this Prometheus instance.
+  labels:
+    monitor: '{{ ansible_hostname }}'
+
+# A scrape configuration containing exactly one endpoint to scrape:
+# Here it's Prometheus itself.
+scrape_configs:
+  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  - job_name: 'ipfs'
+
+    # Override the global default and scrape targets from this job every 5 seconds.
+    scrape_interval: 5s
+    scrape_timeout: 10s
+
+    metrics_path: '/debug/metrics/prometheus'
+
+    target_groups:
+      - targets:
+{% for hostname in cjdns_identities.keys() %}
+        - '[{{ cjdns_identities[hostname].ipv6 }}]:80'
+{% endfor %}

--- a/solarnet/roles/prometheus/vars/main.yml
+++ b/solarnet/roles/prometheus/vars/main.yml
@@ -1,0 +1,2 @@
+---
+prometheus_ref: 5176a480e6326635ad4a8ab76a2f7a10bb52bd55

--- a/solarnet/solarnet.yml
+++ b/solarnet/solarnet.yml
@@ -10,3 +10,9 @@
     - cjdns
     - ipfs
     - ipfs_gateway
+
+- hosts: pluto
+  pre_tasks:
+  - include_vars: secrets.yml
+  roles:
+  - prometheus


### PR DESCRIPTION
Scrapes all gateway hosts' `/debug/metrics/prometheus` and provides a query API and UI.

See it in action: http://pluto.i.ipfs.io/prometheus/graph#[{%22range_input%22%3A%221h%22%2C%22end_input%22%3A%22%22%2C%22step_input%22%3A%22%22%2C%22stacked%22%3A%22%22%2C%22expr%22%3A%22ipfs_p2p_peers_total%22%2C%22tab%22%3A0}]

Prometheus runs its default config, with only the scraping targets added. I left out authentication because I'm not sure it needs to be protected. @jbenet @whyrusleeping wdyt?