### PR TITLE
Make use of cjdns for Prometheus/API/Gateway authentication

### DIFF
--- a/solarnet/cleanup.sh
+++ b/solarnet/cleanup.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
 
-ansible solarnet -f 4 -m shell -a 'rm -v /var/lib/docker/containers/*/*-json.log ; docker restart ipfs ; sleep 2 ; docker rm $(docker ps -f "status=exited" -aq) ; docker rmi $(docker images -f "dangling=true" -aq)'
+for host in `ansible solarnet --list-hosts`; do
+  ssh root@$host.i.ipfs.io 'rm -v /var/lib/docker/containers/*/*-json.log ; docker restart ipfs ; sleep 2 ; docker rm $(docker ps -f "status=exited" -aq) ; docker rmi $(docker images -f "dangling=true" -aq)'
+done

--- a/solarnet/hosts
+++ b/solarnet/hosts
@@ -1,4 +1,3 @@
-[solarnet]
 pluto       ansible_ssh_host=104.236.179.241
 neptune     ansible_ssh_host=104.236.176.52
 uranus      ansible_ssh_host=162.243.248.213
@@ -9,5 +8,4 @@ earth       ansible_ssh_host=178.62.158.247
 mercury     ansible_ssh_host=178.62.61.185
 
 ; managed by whyrusleeping
-[whyrunet]
-mars        ansible_ssh_host=104.131.131.82
+; mars        ansible_ssh_host=104.131.131.82

--- a/solarnet/roles/ipfs/tasks/main.yml
+++ b/solarnet/roles/ipfs/tasks/main.yml
@@ -27,9 +27,9 @@
     command: ipfs daemon
     restart_policy: always
     ports:
-    - 0.0.0.0:8080:8080
     - 0.0.0.0:4001:4001
     - 127.0.0.1:5001:5001
+    - 127.0.0.1:8080:8080
     volumes:
     - /ipfs/ipfs_master:/ipfs
     env:

--- a/solarnet/roles/ipfs_gateway/templates/nginx.conf.j2
+++ b/solarnet/roles/ipfs_gateway/templates/nginx.conf.j2
@@ -1,35 +1,16 @@
 upstream gateway {
-    server {{ inventory_hostname }}{{ fqdn }}:8080;
+    server [{{ cjdns_identities[inventory_hostname].ipv6 }}]:8080;
 
 {% for host in groups[gateway_group] %}
 {% if host != inventory_hostname %}
-    server {{ host }}{{ fqdn }}:8080 backup;
+    server [{{ cjdns_identities[host].ipv6 }}]:8080 backup;
 {% endif %}
 {% endfor %}
 }
 
 server {
-    listen 80;
-    listen [::]:80;
-
-    location /debug {
-{% for hostname in cjdns_identities.keys() %}
-        allow {{ cjdns_identities[hostname].ipv6 }};
-{% endfor %}
-{% for addr in metrics_whitelist %}
-        allow {{ addr }};
-{% endfor %}
-        allow 127.0.0.1;
-        allow ::1;
-        deny all;
-        proxy_pass http://127.0.0.1:5001;
-        proxy_set_header Host $host;
-    }
-
-    location /prometheus {
-        proxy_pass http://127.0.0.1:9090;
-        proxy_set_header Host $host;
-    }
+    listen 80 default_server;
+    listen [::]:80 default_server;
 
     location / {
         proxy_pass http://gateway;
@@ -38,4 +19,59 @@ server {
 
     access_log /var/log/nginx/access.log;
     error_log /var/log/nginx/error.log;
+}
+
+# api
+server {
+    listen [{{ cjdns_identities[inventory_hostname].ipv6 }}]:5001;
+
+    location / {
+{% for hostname in cjdns_identities.keys() %}
+        allow {{ cjdns_identities[hostname].ipv6 }};
+{% endfor %}
+{% for addr in metrics_whitelist %}
+        allow {{ addr }};
+{% endfor %}
+        allow ::1;
+        deny all;
+        proxy_pass http://127.0.0.1:5001;
+        proxy_set_header Host $host;
+    }
+}
+
+# gateway
+server {
+    listen [{{ cjdns_identities[inventory_hostname].ipv6 }}]:8080;
+
+    location / {
+{% for hostname in cjdns_identities.keys() %}
+        allow {{ cjdns_identities[hostname].ipv6 }};
+{% endfor %}
+{% for addr in metrics_whitelist %}
+        allow {{ addr }};
+{% endfor %}
+        allow ::1;
+        deny all;
+        proxy_pass http://127.0.0.1:8080;
+        proxy_set_header Host $host;
+    }
+}
+
+# promdash
+server {
+    listen [{{ cjdns_identities[inventory_hostname].ipv6 }}]:80;
+    server_name metrics.ipfs.io;
+
+    location / {
+{% for hostname in cjdns_identities.keys() %}
+        allow {{ cjdns_identities[hostname].ipv6 }};
+{% endfor %}
+{% for addr in metrics_whitelist %}
+        allow {{ addr }};
+{% endfor %}
+        allow ::1;
+        deny all;
+        proxy_pass http://127.0.0.1:9090;
+        proxy_set_header Host $host;
+    }
 }

--- a/solarnet/roles/prometheus/files/Dockerfile
+++ b/solarnet/roles/prometheus/files/Dockerfile
@@ -24,6 +24,5 @@ WORKDIR    /prometheus
 ENTRYPOINT [ "/bin/prometheus" ]
 CMD        [ "-config.file=/etc/prometheus/prometheus.yml", \
              "-storage.local.path=/prometheus", \
-             "-web.path-prefix=/prometheus", \
              "-web.console.libraries=/etc/prometheus/console_libraries", \
              "-web.console.templates=/etc/prometheus/consoles" ]

--- a/solarnet/roles/prometheus/tasks/main.yml
+++ b/solarnet/roles/prometheus/tasks/main.yml
@@ -42,5 +42,6 @@
 # apply config update
 - docker:
     name: prometheus
+    image: "prometheus:{{ prometheus_ref }}"
     state: restarted
   when: "prometheus_yml.changed"

--- a/solarnet/roles/prometheus/templates/prometheus.yml.j2
+++ b/solarnet/roles/prometheus/templates/prometheus.yml.j2
@@ -23,5 +23,5 @@ scrape_configs:
     target_groups:
       - targets:
 {% for hostname in cjdns_identities.keys() %}
-        - '[{{ cjdns_identities[hostname].ipv6 }}]:80'
+        - '[{{ cjdns_identities[hostname].ipv6 }}]:5001'
 {% endfor %}

--- a/solarnet/solarnet.yml
+++ b/solarnet/solarnet.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: solarnet
+- hosts: all
   vars:
     gateway_group: all
     fqdn: .i.ipfs.io

--- a/solarnet/solarnet.yml
+++ b/solarnet/solarnet.yml
@@ -2,7 +2,6 @@
 - hosts: all
   vars:
     gateway_group: all
-    fqdn: .i.ipfs.io
   pre_tasks:
   - include_vars: secrets.yml
   roles:


### PR DESCRIPTION
- gateway at http://[fc12::3456]:8080
- api at http://[fc12::3456]:5001
- prometheus at http://[fc12::3456]:80 / http://metrics.ipfs.io

All of them require authentication with a whitelisted
cjdns IPv6 address (see secrets.yml).

The other three commits are semi-random fixes.