### PR TITLE
Fix nginx gateway vhost

### DIFF
--- a/solarnet/roles/ipfs_gateway/templates/nginx.conf.j2
+++ b/solarnet/roles/ipfs_gateway/templates/nginx.conf.j2
@@ -11,6 +11,7 @@ upstream gateway {
 server {
     listen 80 default_server;
     listen [::]:80 default_server;
+    listen [{{ cjdns_identities[inventory_hostname].ipv6 }}]:80 default_server;
 
     location / {
         proxy_pass http://gateway;

--- a/solarnet/roles/ipfs_gateway/templates/nginx.conf.j2
+++ b/solarnet/roles/ipfs_gateway/templates/nginx.conf.j2
@@ -18,8 +18,8 @@ server {
         proxy_set_header Host $host;
     }
 
-    access_log /var/log/nginx/access.log;
-    error_log /var/log/nginx/error.log;
+    access_log /var/log/nginx/default.access.log;
+    error_log /var/log/nginx/default.error.log;
 }
 
 # api
@@ -38,6 +38,9 @@ server {
         proxy_pass http://127.0.0.1:5001;
         proxy_set_header Host $host;
     }
+
+    access_log /var/log/nginx/api.access.log;
+    error_log /var/log/nginx/api.error.log;
 }
 
 # gateway
@@ -56,6 +59,9 @@ server {
         proxy_pass http://127.0.0.1:8080;
         proxy_set_header Host $host;
     }
+
+    access_log /var/log/nginx/gateway.access.log;
+    error_log /var/log/nginx/gateway.error.log;
 }
 
 # promdash
@@ -75,4 +81,7 @@ server {
         proxy_pass http://127.0.0.1:9090;
         proxy_set_header Host $host;
     }
+
+    access_log /var/log/nginx/metrics.access.log;
+    error_log /var/log/nginx/metrics.error.log;
 }


### PR DESCRIPTION
If coming in via the cjdns address, the metrics.ipfs.io host would incorrectly be used as the default host since it's more granular than [::].