### PR TITLE
ipfs: disable regular IPFS restarts

### DIFF
--- a/solarnet/roles/ipfs/tasks/main.yml
+++ b/solarnet/roles/ipfs/tasks/main.yml
@@ -47,7 +47,7 @@
     job: /ipfs/maybe-restart.sh 25 docker restart ipfs
     minute: 55,25
     hour: "*"
-    state: present
+    state: absent
     name: maybe-restart
     cron_file: ipfs-maybe-restart
     user: root


### PR DESCRIPTION
We have monitoring now, which will yield more interesting results if we don't restart a few IPFS daemons every half an hour.

License: MIT
Signed-off-by: Lars Gierth <larsg@systemli.org>