### PR TITLE
Fix bootstrapping of fresh hosts

### DIFF
--- a/solarnet/roles/cjdns/tasks/main.yml
+++ b/solarnet/roles/cjdns/tasks/main.yml
@@ -16,7 +16,7 @@
   when: "cjdns_ref_present.rc != 0"
 
 - name: install cjdroute
-  shell: "mv /usr/bin/cjdroute /usr/bin/cjdroute.old && cp /opt/cjdns/cjdroute /usr/bin/"
+  shell: "mv /usr/bin/cjdroute /usr/bin/cjdroute.old ; cp /opt/cjdns/cjdroute /usr/bin/"
   when: "cjdns_ref_present.rc != 0"
 
 - name: install cjdroute.conf

--- a/solarnet/roles/common/tasks/main.yml
+++ b/solarnet/roles/common/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 - authorized_key: 'user=root key="{{ item }}"'
   with_items: "{{ authorized_keys }}"
+- hostname: "name={{ inventory_hostname }}"
 - command: apt-get install -y mosh vim htop screen bridge-utils build-essential autoconf libtool bison flex nodejs mercurial git
 - file:
     src: /usr/bin/nodejs

--- a/solarnet/roles/common/tasks/main.yml
+++ b/solarnet/roles/common/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - authorized_key: 'user=root key="{{ item }}"'
   with_items: "{{ authorized_keys }}"
-- command: apt-get install -y mosh vim htop screen bridge-utils build-essential autoconf libtool bison flex nodejs mercurial
+- command: apt-get install -y mosh vim htop screen bridge-utils build-essential autoconf libtool bison flex nodejs mercurial git
 - file:
     src: /usr/bin/nodejs
     path: /usr/bin/node

--- a/solarnet/roles/docker/files/get-docker.sh
+++ b/solarnet/roles/docker/files/get-docker.sh
@@ -1,0 +1,277 @@
+#!/bin/sh
+
+# Changes by @lgierth:
+# - unindented EOFs
+
+set -e
+#
+# This script is meant for quick & easy install via:
+#   'curl -sSL https://get.docker.com/ | sh'
+# or:
+#   'wget -qO- https://get.docker.com/ | sh'
+#
+#
+# Docker Maintainers:
+#   To update this script on https://get.docker.com,
+#   use hack/release.sh during a normal release,
+#   or the following one-liner for script hotfixes:
+#     s3cmd put --acl-public -P hack/install.sh s3://get.docker.com/index
+#
+
+url='https://get.docker.com/'
+
+command_exists() {
+  command -v "$@" > /dev/null 2>&1
+}
+
+echo_docker_as_nonroot() {
+  your_user=your-user
+  [ "$user" != 'root' ] && your_user="$user"
+  # intentionally mixed spaces and tabs here -- tabs are stripped by "<<-EOF", spaces are kept in the output
+  cat <<-EOF
+
+  If you would like to use Docker as a non-root user, you should now consider
+  adding your user to the "docker" group with something like:
+
+    sudo usermod -aG docker $your_user
+
+  Remember that you will have to log out and back in for this to take effect!
+
+EOF
+}
+
+do_install() {
+  case "$(uname -m)" in
+    *64)
+      ;;
+    *)
+      cat >&2 <<-'EOF'
+      Error: you are not using a 64bit platform.
+      Docker currently only supports 64bit platforms.
+EOF
+      exit 1
+      ;;
+  esac
+
+  if command_exists docker; then
+    cat >&2 <<-'EOF'
+      Warning: the "docker" command appears to already exist on this system.
+
+      If you already have Docker installed, this script can cause trouble, which is
+      why we're displaying this warning and provide the opportunity to cancel the
+      installation.
+
+      If you installed the current Docker package using this script and are using it
+      again to update Docker, you can safely ignore this message.
+
+      You may press Ctrl+C now to abort this script.
+EOF
+    ( set -x; sleep 20 )
+  fi
+
+  user="$(id -un 2>/dev/null || true)"
+
+  sh_c='sh -c'
+  if [ "$user" != 'root' ]; then
+    if command_exists sudo; then
+      sh_c='sudo -E sh -c'
+    elif command_exists su; then
+      sh_c='su -c'
+    else
+      cat >&2 <<-'EOF'
+      Error: this installer needs the ability to run commands as root.
+      We are unable to find either "sudo" or "su" available to make this happen.
+EOF
+      exit 1
+    fi
+  fi
+
+  curl=''
+  if command_exists curl; then
+    curl='curl -sSL'
+  elif command_exists wget; then
+    curl='wget -qO-'
+  elif command_exists busybox && busybox --list-modules | grep -q wget; then
+    curl='busybox wget -qO-'
+  fi
+
+  # perform some very rudimentary platform detection
+  lsb_dist=''
+  if command_exists lsb_release; then
+    lsb_dist="$(lsb_release -si)"
+  fi
+  if [ -z "$lsb_dist" ] && [ -r /etc/lsb-release ]; then
+    lsb_dist="$(. /etc/lsb-release && echo "$DISTRIB_ID")"
+  fi
+  if [ -z "$lsb_dist" ] && [ -r /etc/debian_version ]; then
+    lsb_dist='debian'
+  fi
+  if [ -z "$lsb_dist" ] && [ -r /etc/fedora-release ]; then
+    lsb_dist='fedora'
+  fi
+  if [ -z "$lsb_dist" ] && [ -r /etc/os-release ]; then
+    lsb_dist="$(. /etc/os-release && echo "$ID")"
+  fi
+
+  lsb_dist="$(echo "$lsb_dist" | tr '[:upper:]' '[:lower:]')"
+  case "$lsb_dist" in
+    amzn|fedora|centos)
+      if [ "$lsb_dist" = 'amzn' ]; then
+        (
+          set -x
+          $sh_c 'sleep 3; yum -y -q install docker'
+        )
+      else
+        (
+          set -x
+          $sh_c 'sleep 3; yum -y -q install docker-io'
+        )
+      fi
+      if command_exists docker && [ -e /var/run/docker.sock ]; then
+        (
+          set -x
+          $sh_c 'docker version'
+        ) || true
+      fi
+      echo_docker_as_nonroot
+      exit 0
+      ;;
+
+    'opensuse project'|opensuse|'suse linux'|sled)
+      (
+        set -x
+        $sh_c 'sleep 3; zypper -n install docker'
+      )
+      if command_exists docker && [ -e /var/run/docker.sock ]; then
+        (
+          set -x
+          $sh_c 'docker version'
+        ) || true
+      fi
+      echo_docker_as_nonroot
+      exit 0
+      ;;
+
+    ubuntu|debian|linuxmint|'elementary os'|kali)
+      export DEBIAN_FRONTEND=noninteractive
+
+      did_apt_get_update=
+      apt_get_update() {
+        if [ -z "$did_apt_get_update" ]; then
+          ( set -x; $sh_c 'sleep 3; apt-get update' )
+          did_apt_get_update=1
+        fi
+      }
+
+      # aufs is preferred over devicemapper; try to ensure the driver is available.
+      if ! grep -q aufs /proc/filesystems && ! $sh_c 'modprobe aufs'; then
+        if uname -r | grep -q -- '-generic' && dpkg -l 'linux-image-*-generic' | grep -q '^ii' 2>/dev/null; then
+          kern_extras="linux-image-extra-$(uname -r) linux-image-extra-virtual"
+
+          apt_get_update
+          ( set -x; $sh_c 'sleep 3; apt-get install -y -q '"$kern_extras" ) || true
+
+          if ! grep -q aufs /proc/filesystems && ! $sh_c 'modprobe aufs'; then
+            echo >&2 'Warning: tried to install '"$kern_extras"' (for AUFS)'
+            echo >&2 ' but we still have no AUFS.  Docker may not work. Proceeding anyways!'
+            ( set -x; sleep 10 )
+          fi
+        else
+          echo >&2 'Warning: current kernel is not supported by the linux-image-extra-virtual'
+          echo >&2 ' package.  We have no AUFS support.  Consider installing the packages'
+          echo >&2 ' linux-image-virtual kernel and linux-image-extra-virtual for AUFS support.'
+          ( set -x; sleep 10 )
+        fi
+      fi
+
+      # install apparmor utils if they're missing and apparmor is enabled in the kernel
+      # otherwise Docker will fail to start
+      if [ "$(cat /sys/module/apparmor/parameters/enabled 2>/dev/null)" = 'Y' ]; then
+        if command -v apparmor_parser &> /dev/null; then
+          echo 'apparmor is enabled in the kernel and apparmor utils were already installed'
+        else
+          echo 'apparmor is enabled in the kernel, but apparmor_parser missing'
+          apt_get_update
+          ( set -x; $sh_c 'sleep 3; apt-get install -y -q apparmor' )
+        fi
+      fi
+
+      if [ ! -e /usr/lib/apt/methods/https ]; then
+        apt_get_update
+        ( set -x; $sh_c 'sleep 3; apt-get install -y -q apt-transport-https ca-certificates' )
+      fi
+      if [ -z "$curl" ]; then
+        apt_get_update
+        ( set -x; $sh_c 'sleep 3; apt-get install -y -q curl ca-certificates' )
+        curl='curl -sSL'
+      fi
+      (
+        set -x
+        if [ "https://get.docker.com/" = "$url" ]; then
+          $sh_c "apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9"
+        elif [ "https://test.docker.com/" = "$url" ]; then
+          $sh_c "apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 740B314AE3941731B942C66ADF4FD13717AAD7D6"
+        elif [ "https://experimental.docker.com/" = "$url" ]; then
+          $sh_c "apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys E33FF7BF5C91D50A6F91FFFD4CC38D40F9A96B49"
+        else
+          $sh_c "$curl ${url}gpg | apt-key add -"
+        fi
+        $sh_c "echo deb ${url}ubuntu docker main > /etc/apt/sources.list.d/docker.list"
+        $sh_c 'sleep 3; apt-get update; apt-get install -y -q lxc-docker'
+      )
+      if command_exists docker && [ -e /var/run/docker.sock ]; then
+        (
+          set -x
+          $sh_c 'docker version'
+        ) || true
+      fi
+      echo_docker_as_nonroot
+      exit 0
+      ;;
+
+    gentoo)
+      if [ "$url" = "https://test.docker.com/" ]; then
+        # intentionally mixed spaces and tabs here -- tabs are stripped by "<<-'EOF'", spaces are kept in the output
+        cat >&2 <<-'EOF'
+
+          You appear to be trying to install the latest nightly build in Gentoo.'
+          The portage tree should contain the latest stable release of Docker, but'
+          if you want something more recent, you can always use the live ebuild'
+          provided in the "docker" overlay available via layman.  For more'
+          instructions, please see the following URL:'
+
+            https://github.com/tianon/docker-overlay#using-this-overlay'
+
+          After adding the "docker" overlay, you should be able to:'
+
+            emerge -av =app-emulation/docker-9999'
+
+EOF
+        exit 1
+      fi
+
+      (
+        set -x
+        $sh_c 'sleep 3; emerge app-emulation/docker'
+      )
+      exit 0
+      ;;
+  esac
+
+  # intentionally mixed spaces and tabs here -- tabs are stripped by "<<-'EOF'", spaces are kept in the output
+  cat >&2 <<-'EOF'
+
+    Either your platform is not easily detectable, is not supported by this
+    installer script (yet - PRs welcome! [hack/install.sh]), or does not yet have
+    a package for Docker.  Please visit the following URL for more detailed
+    installation instructions:
+
+      https://docs.docker.com/en/latest/installation/
+
+EOF
+  exit 1
+}
+
+# wrapped up in a function so that we have some protection against only getting
+# half the file during "curl | sh"
+do_install

--- a/solarnet/roles/docker/tasks/main.yml
+++ b/solarnet/roles/docker/tasks/main.yml
@@ -1,11 +1,21 @@
 ---
+- name: check docker
+  command: docker -v
+  ignore_errors: true
+  register: docker_present
+- name: copy get.docker.io script
+  copy: src=get-docker.sh dest=/tmp
+  when: docker_present.rc != 0
+- name: install docker
+  shell: cat /tmp/get-docker.sh | sh
+  when: docker_present.rc != 0
+
 - name: "copy pip install file"
   copy: src=get-pip.py dest=/tmp/get-pip.py
 - name: "install pip"
   shell: "python /tmp/get-pip.py"
 - name: "install docker-py"
   pip: name=docker-py
-- name: "install fig"
-  pip: name=fig
+
 - name: "create directory for containers"
   file: path=/containers state=directory

--- a/solarnet/roles/ipfs/tasks/main.yml
+++ b/solarnet/roles/ipfs/tasks/main.yml
@@ -36,7 +36,21 @@
       IPFS_PATH: /ipfs/repo
       IPFS_LOGGING: debug
 
+# generate ipfs repo
+- command: "docker exec ipfs:{{ ipfs_ref }} sh -c 'IPFS_PATH=/ipfs/repo ipfs init'"
+  args:
+    creates: /ipfs/ipfs_master/repo
+  register: ipfs_init
 - command: docker exec ipfs ipfs config Addresses.API /ip4/0.0.0.0/tcp/5001
+  when: ipfs_init.changed
+- command: docker exec ipfs ipfs config Addresses.Gateway /ip4/0.0.0.0/tcp/8080
+  when: ipfs_init.changed
+- docker:
+    name: ipfs
+    image: "ipfs:{{ ipfs_ref }}"
+    state: restarted
+  when: ipfs_init.changed
+
 
 # restart the ipfs container every 30 minutes, with a 25 % chance
 - copy:

--- a/solarnet/roles/ipfs_gateway/tasks/main.yml
+++ b/solarnet/roles/ipfs_gateway/tasks/main.yml
@@ -1,28 +1,30 @@
 ---
 - name: "create directory for container"
   file: path=/containers/{{ docker_container_name }} state=directory
+# XXX: migration from dockerfile/nginx to nginx image
+- name: migrate conf directory
+  shell: "[ -d sites-enabled ]] && mv sites-enabled conf.d"
+  args:
+    chdir: "/containers/{{ docker_container_name }}"
+  ignore_errors: true
 - name: "create directory for conf"
-  file: path=/containers/{{ docker_container_name }}/sites-enabled state=directory
+  file: path=/containers/{{ docker_container_name }}/conf.d state=directory
 - name: "copy nginx config"
   template:
     src: nginx.conf.j2
-    dest: /containers/{{ docker_container_name }}/sites-enabled/nginx.conf # TODO extract docker_container_name var
+    dest: /containers/{{ docker_container_name }}/conf.d/nginx.conf # TODO extract docker_container_name var
   register: nginx_config
 - name: "run nginx"
   docker:
     state: reloaded
     name: "{{ docker_container_name }}"
-    image: dockerfile/nginx
+    image: nginx:1.9.3
     volumes:
-        - /containers/{{ docker_container_name }}/sites-enabled:/etc/nginx/sites-enabled
+        - /containers/{{ docker_container_name }}/conf.d:/etc/nginx/conf.d
         - /containers/{{ docker_container_name }}/certs:/etc/nginx/certs
         - /containers/{{ docker_container_name }}/logs:/var/log/nginx
     net: host
-    command: nginx
     restart_policy: always
-- name: "restart nginx for config change"
-  docker:
-    state: restarted
-    name: "{{ docker_container_name }}"
-    image: dockerfile/nginx
+- name: "reload nginx for config change"
+  command: docker exec ipfs_gateway_proxy /etc/init.d/nginx reload
   when: nginx_config.changed

--- a/solarnet/roles/metrics/tasks/main.yml
+++ b/solarnet/roles/metrics/tasks/main.yml
@@ -72,10 +72,10 @@
 
 # nginx vhost
 - file: path=/containers/ipfs_gateway_proxy state=directory
-- file: path=/containers/ipfs_gateway_proxy/sites-enabled state=directory
+- file: path=/containers/ipfs_gateway_proxy/conf.d state=directory
 - template:
     src: metrics.conf.j2
-    dest: /containers/ipfs_gateway_proxy/sites-enabled/metrics.conf
+    dest: /containers/ipfs_gateway_proxy/conf.d/metrics.conf
   register: nginx_metrics_conf
 - command: docker exec ipfs_gateway_proxy /etc/init.d/nginx reload
   when: nginx_metrics_conf.changed

--- a/solarnet/roles/node_exporter/tasks/main.yml
+++ b/solarnet/roles/node_exporter/tasks/main.yml
@@ -38,10 +38,10 @@
   when: "node_exporter_ref_present.rc != 0"
 
 - file: path=/containers/ipfs_gateway_proxy state=directory
-- file: path=/containers/ipfs_gateway_proxy/sites-enabled state=directory
+- file: path=/containers/ipfs_gateway_proxy/conf.d state=directory
 - template:
     src: nginx_node_exporter.conf.j2
-    dest: /containers/ipfs_gateway_proxy/sites-enabled/node_exporter.conf
+    dest: /containers/ipfs_gateway_proxy/conf.d/node_exporter.conf
   register: nginx_node_exporter
 - command: docker exec ipfs_gateway_proxy /etc/init.d/nginx reload
   when: nginx_node_exporter.changed


### PR DESCRIPTION
These are fixes which were neccessary for rebuilding Pluto (others will follow). Most notably:

- install docker using vendored get.docker.ui script
- run the `nginx` image instead of the dead `dockerfile/nginx` image.
- set hostname from inventory file