### PR TITLE
ipfs: manage repo config with ansible

### DIFF
--- a/solarnet/roles/ipfs/tasks/main.yml
+++ b/solarnet/roles/ipfs/tasks/main.yml
@@ -41,15 +41,17 @@
   args:
     creates: /ipfs/ipfs_master/repo
   register: ipfs_init
-- command: docker exec ipfs ipfs config Addresses.API /ip4/0.0.0.0/tcp/5001
-  when: ipfs_init.changed
-- command: docker exec ipfs ipfs config Addresses.Gateway /ip4/0.0.0.0/tcp/8080
-  when: ipfs_init.changed
+- name: install ipfs config
+  template:
+    src: config.j2
+    dest: /ipfs/ipfs_master/repo/config
+    mode: 0400
+  register: ipfs_config
 - docker:
     name: ipfs
     image: "ipfs:{{ ipfs_ref }}"
     state: restarted
-  when: ipfs_init.changed
+  when: ipfs_init.changed or ipfs_config.changed
 
 
 # restart the ipfs container every 30 minutes, with a 25 % chance

--- a/solarnet/roles/ipfs/templates/config.j2
+++ b/solarnet/roles/ipfs/templates/config.j2
@@ -1,0 +1,62 @@
+{
+  "Identity": {
+    "PeerID": "{{ ipfs_identities[inventory_hostname].peer_id }}",
+    "PrivKey": "{{ ipfs_identities[inventory_hostname].private_key }}"
+  },
+  "Datastore": {
+    "Type": "leveldb",
+    "Path": "/ipfs/repo/datastore"
+  },
+  "Addresses": {
+    "Swarm": [
+      "/ip4/0.0.0.0/tcp/4001"
+    ],
+    "API": "/ip4/0.0.0.0/tcp/5001",
+    "Gateway": "/ip4/0.0.0.0/tcp/8080"
+  },
+  "Mounts": {
+    "IPFS": "/ipfs",
+    "IPNS": "/ipns",
+    "FuseAllowOther": false
+  },
+  "Version": {
+    "Current": "0.3.5",
+    "Check": "error",
+    "CheckDate": "0001-01-01T00:00:00Z",
+    "CheckPeriod": "172800000000000",
+    "AutoUpdate": "minor"
+  },
+  "Discovery": {
+    "MDNS": {
+      "Enabled": false,
+      "Interval": 10
+    }
+  },
+  "Bootstrap": [
+    "/ip4/104.131.131.82/tcp/4001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",
+    "/ip4/104.236.176.52/tcp/4001/ipfs/QmSoLnSGccFuZQJzRadHn95W2CrSFmZuTdDWP8HXaHca9z",
+    "/ip4/104.236.179.241/tcp/4001/ipfs/QmSoLpPVmHKQ4XTPdz8tjDFgdeRFkpV8JgYq8JVJ69RrZm",
+    "/ip4/162.243.248.213/tcp/4001/ipfs/QmSoLueR4xBeUbY9WZ9xGUUxunbKWcrNFTDAadQJmocnWm",
+    "/ip4/128.199.219.111/tcp/4001/ipfs/QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu",
+    "/ip4/104.236.76.40/tcp/4001/ipfs/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64",
+    "/ip4/178.62.158.247/tcp/4001/ipfs/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd",
+    "/ip4/178.62.61.185/tcp/4001/ipfs/QmSoLMeWqB7YGVLJN3pNLQpmmEk35v6wYtsMGLzSr5QBU3",
+    "/ip4/104.236.151.122/tcp/4001/ipfs/QmSoLju6m7xTh3DuokvT3886QRYqxAzb1kShaanJgW36yx"
+  ],
+  "Tour": {
+    "Last": ""
+  },
+  "Gateway": {
+    "RootRedirect": "",
+    "Writable": false
+  },
+  "SupernodeRouting": {
+    "Servers": []
+  },
+  "DialBlocklist": null,
+  "Log": {
+    "MaxSizeMB": 250,
+    "MaxBackups": 1,
+    "MaxAgeDays": 0
+  }
+}

--- a/solarnet/secrets.yml.example
+++ b/solarnet/secrets.yml.example
@@ -31,3 +31,9 @@ cjdns_authorized_passwords:
 # additional hosts allowed to access /debug
 metrics_whitelist:
   - fc65::4321
+
+# output of `ipfs config Identity`, per inventory host
+ipfs_identities:
+  some_inventory_hostname:
+    peer_id: Qmthepeerid
+    private_key: the-ipfs-private-key


### PR DESCRIPTION
No more lost private keys! Safely rebuild hosts! This is pretty much a standard config, but with MDNS disabled, and SupernodeRouting removed. The bootstrap nodes can be removed too, once we can discover peers from cjdns.

License: MIT
Signed-off-by: Lars Gierth <larsg@systemli.org>