### PR TITLE
Bootstrap fixes

### DIFF
--- a/solarnet/roles/common/tasks/main.yml
+++ b/solarnet/roles/common/tasks/main.yml
@@ -2,7 +2,7 @@
 - authorized_key: 'user=root key="{{ item }}"'
   with_items: "{{ authorized_keys }}"
 - hostname: "name={{ inventory_hostname }}"
-- command: apt-get install -y mosh vim htop screen bridge-utils build-essential autoconf libtool bison flex nodejs mercurial git
+- shell: "apt-get update && apt-get install -y mosh vim htop screen bridge-utils build-essential autoconf libtool bison flex nodejs mercurial git"
 - file:
     src: /usr/bin/nodejs
     path: /usr/bin/node

--- a/solarnet/roles/docker/tasks/main.yml
+++ b/solarnet/roles/docker/tasks/main.yml
@@ -15,7 +15,7 @@
 - name: "install pip"
   shell: "python /tmp/get-pip.py"
 - name: "install docker-py"
-  pip: name=docker-py
+  pip: name=docker-py version=0.5.3
 
 - name: "create directory for containers"
   file: path=/containers state=directory

--- a/solarnet/roles/ipfs/tasks/main.yml
+++ b/solarnet/roles/ipfs/tasks/main.yml
@@ -20,6 +20,9 @@
   when: "ipfs_image_present.rc != 0"
 
 # assert ipfs container runs and is up-to-date
+# XXX: with docker-py 1.3.1 this tries (and fails) to pull ipfs
+#      if no ipfs image was present before the previous task.
+#      docker-py 0.5.3 is known to be working.
 - docker:
     name: ipfs
     image: "ipfs:{{ ipfs_ref }}"

--- a/solarnet/roles/ipfs/tasks/main.yml
+++ b/solarnet/roles/ipfs/tasks/main.yml
@@ -19,6 +19,17 @@
 - shell: "docker build -t ipfs:{{ ipfs_ref }} /ipfs_build"
   when: "ipfs_image_present.rc != 0"
 
+# generate ipfs repo
+- command: "docker run -i -v /ipfs/ipfs_master:/ipfs ipfs:{{ ipfs_ref }} sh -c 'IPFS_PATH=/ipfs/repo ipfs init'"
+  args:
+    creates: /ipfs/ipfs_master/repo
+- name: install ipfs config
+  template:
+    src: config.j2
+    dest: /ipfs/ipfs_master/repo/config
+    mode: 0400
+  register: ipfs_config
+
 # assert ipfs container runs and is up-to-date
 # XXX: with docker-py 1.3.1 this tries (and fails) to pull ipfs
 #      if no ipfs image was present before the previous task.
@@ -38,23 +49,11 @@
     env:
       IPFS_PATH: /ipfs/repo
       IPFS_LOGGING: debug
-
-# generate ipfs repo
-- command: "docker exec ipfs:{{ ipfs_ref }} sh -c 'IPFS_PATH=/ipfs/repo ipfs init'"
-  args:
-    creates: /ipfs/ipfs_master/repo
-  register: ipfs_init
-- name: install ipfs config
-  template:
-    src: config.j2
-    dest: /ipfs/ipfs_master/repo/config
-    mode: 0400
-  register: ipfs_config
 - docker:
     name: ipfs
     image: "ipfs:{{ ipfs_ref }}"
     state: restarted
-  when: ipfs_init.changed or ipfs_config.changed
+  when: ipfs_config.changed
 
 
 # restart the ipfs container every 30 minutes, with a 25 % chance


### PR DESCRIPTION
commit 35abbee97fa9a17b83126c3a6d901b449f2df397
Author: Lars Gierth <larsg@systemli.org>
Date:   Thu Jul 30 00:28:32 2015 +0200

    ipfs: run ipfs init using one-shot container
    
    Previously, when ipfs init hadn't been run yet, the
    container would go into a restart loop, and thus
    `docker exec` in that looping container would fail
    to execute `ipfs init`.
    
    License: MIT
    Signed-off-by: Lars Gierth <larsg@systemli.org>

commit 7842b7ce1e0def7b50ba17803231742d3cf6eba2
Author: Lars Gierth <larsg@systemli.org>
Date:   Thu Jul 30 00:27:22 2015 +0200

    docker: pin to known-working docker-py 0.5.3
    
    The latest is failing to recognize locally-built images
    and always tries to pull them from the registry.
    
    No idea why pip picked an old (but working) version
    during the previous rebuild of pluto. Anyhow, I'm not
    going to sink time into figuring out either of these
    issues now.
    
    License: MIT
    Signed-off-by: Lars Gierth <larsg@systemli.org>

commit 8da496b7251de1b924764f245b220d84aba2f21d
Author: Lars Gierth <larsg@systemli.org>
Date:   Wed Jul 29 03:57:28 2015 +0200

    common: run apt-get update
    
    In order to avoid hitting package versions which were removed
    for security reasons, and such stuff.
    
    License: MIT
    Signed-off-by: Lars Gierth <larsg@systemli.org>