### PR TITLE
Decouple nginx from ipfs_gateway, move pinbot and metrics to scruffy

### DIFF
--- a/solarnet/hosts
+++ b/solarnet/hosts
@@ -1,3 +1,4 @@
+[gateway]
 pluto       ansible_ssh_host=104.236.179.241
 neptune     ansible_ssh_host=104.236.176.52
 uranus      ansible_ssh_host=162.243.248.213

--- a/solarnet/hosts
+++ b/solarnet/hosts
@@ -10,3 +10,9 @@ mercury     ansible_ssh_host=178.62.61.185
 
 ; managed by whyrusleeping
 ; mars        ansible_ssh_host=104.131.131.82
+
+[util]
+scruffy     ansible_ssh_host=104.131.3.162
+
+; TODO: backup for scruffy
+; willie      ansible_ssh_host=todo

--- a/solarnet/roles/ipfs/tasks/main.yml
+++ b/solarnet/roles/ipfs/tasks/main.yml
@@ -53,6 +53,13 @@
     state: restarted
   when: ipfs_init.changed or ipfs_config.changed
 
+# nginx vhost for :5001 and :8080 (api/gateway)
+- file: path=/opt/nginx/conf.d state=directory
+- template:
+    src: nginx_ipfs.conf.j2
+    dest: /opt/nginx/conf.d/ipfs.conf
+  notify: reload nginx
+
 
 # restart the ipfs container every 30 minutes, with a 25 % chance
 - copy:

--- a/solarnet/roles/ipfs/templates/nginx_ipfs.conf.j2
+++ b/solarnet/roles/ipfs/templates/nginx_ipfs.conf.j2
@@ -1,29 +1,3 @@
-server_names_hash_bucket_size 64;
-
-upstream gateway {
-    server [{{ cjdns_identities[inventory_hostname].ipv6 }}]:8080;
-
-{% for host in groups[gateway_group] %}
-{% if host != inventory_hostname %}
-    server [{{ cjdns_identities[host].ipv6 }}]:8080 backup;
-{% endif %}
-{% endfor %}
-}
-
-server {
-    listen 80 default_server;
-    listen [::]:80 default_server;
-    listen [{{ cjdns_identities[inventory_hostname].ipv6 }}]:80 default_server;
-
-    location / {
-        proxy_pass http://gateway;
-        proxy_set_header Host $host;
-    }
-
-    access_log /var/log/nginx/default.access.log;
-    error_log /var/log/nginx/default.error.log;
-}
-
 # api
 server {
     listen [{{ cjdns_identities[inventory_hostname].ipv6 }}]:5001;

--- a/solarnet/roles/ipfs_gateway/tasks/main.yml
+++ b/solarnet/roles/ipfs_gateway/tasks/main.yml
@@ -1,30 +1,7 @@
 ---
-- name: "create directory for container"
-  file: path=/containers/{{ docker_container_name }} state=directory
-# XXX: migration from dockerfile/nginx to nginx image
-- name: migrate conf directory
-  shell: "[ -d sites-enabled ]] && mv sites-enabled conf.d"
-  args:
-    chdir: "/containers/{{ docker_container_name }}"
-  ignore_errors: true
-- name: "create directory for conf"
-  file: path=/containers/{{ docker_container_name }}/conf.d state=directory
-- name: "copy nginx config"
+- name: install nginx config
   template:
-    src: nginx.conf.j2
-    dest: /containers/{{ docker_container_name }}/conf.d/nginx.conf # TODO extract docker_container_name var
-  register: nginx_config
-- name: "run nginx"
-  docker:
-    state: reloaded
-    name: "{{ docker_container_name }}"
-    image: nginx:1.9.3
-    volumes:
-        - /containers/{{ docker_container_name }}/conf.d:/etc/nginx/conf.d
-        - /containers/{{ docker_container_name }}/certs:/etc/nginx/certs
-        - /containers/{{ docker_container_name }}/logs:/var/log/nginx
-    net: host
-    restart_policy: always
-- name: "reload nginx for config change"
-  command: docker exec ipfs_gateway_proxy /etc/init.d/nginx reload
-  when: nginx_config.changed
+    src: nginx_ipfs_gateway.conf.j2
+    dest: /opt/nginx/conf.d/ipfs_gateway.conf
+  notify:
+    - reload nginx

--- a/solarnet/roles/ipfs_gateway/templates/nginx_ipfs_gateway.conf.j2
+++ b/solarnet/roles/ipfs_gateway/templates/nginx_ipfs_gateway.conf.j2
@@ -1,0 +1,23 @@
+upstream gateway {
+    server 127.0.0.1:8080;
+
+{% for host in groups[gateway_group] %}
+{% if host != inventory_hostname %}
+    server [{{ cjdns_identities[host].ipv6 }}]:8080 backup;
+{% endif %}
+{% endfor %}
+}
+
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    listen [{{ cjdns_identities[inventory_hostname].ipv6 }}]:80 default_server;
+
+    location / {
+        proxy_pass http://gateway;
+        proxy_set_header Host $host;
+    }
+
+    access_log /var/log/nginx/default.access.log;
+    error_log /var/log/nginx/default.error.log;
+}

--- a/solarnet/roles/ipfs_gateway/vars/main.yml
+++ b/solarnet/roles/ipfs_gateway/vars/main.yml
@@ -1,2 +1,0 @@
----
-docker_container_name: ipfs_gateway_proxy

--- a/solarnet/roles/metrics/tasks/main.yml
+++ b/solarnet/roles/metrics/tasks/main.yml
@@ -71,11 +71,8 @@
   when: "grafana_ini.changed"
 
 # nginx vhost
-- file: path=/containers/ipfs_gateway_proxy state=directory
-- file: path=/containers/ipfs_gateway_proxy/conf.d state=directory
+- file: path=/opt/nginx/conf.d state=directory
 - template:
     src: metrics.conf.j2
-    dest: /containers/ipfs_gateway_proxy/conf.d/metrics.conf
-  register: nginx_metrics_conf
-- command: docker exec ipfs_gateway_proxy /etc/init.d/nginx reload
-  when: nginx_metrics_conf.changed
+    dest: /opt/nginx/conf.d/metrics.conf
+  notify: reload nginx

--- a/solarnet/roles/metrics/templates/prometheus.yml.j2
+++ b/solarnet/roles/metrics/templates/prometheus.yml.j2
@@ -12,7 +12,7 @@ scrape_configs:
     metrics_path: '/debug/metrics/prometheus'
     target_groups:
       - targets:
-{% for hostname in cjdns_identities.keys() %}
+{% for hostname in groups[gateway_group] %}
         - '[{{ cjdns_identities[hostname].ipv6 }}]:5001'
 {% endfor %}
 

--- a/solarnet/roles/nginx/handlers/main.yml
+++ b/solarnet/roles/nginx/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: reload nginx
+  command: docker exec nginx /etc/init.d/nginx reload

--- a/solarnet/roles/nginx/tasks/main.yml
+++ b/solarnet/roles/nginx/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- name: create config directory
+  file: path=/opt/nginx/conf.d state=directory
+- name: install config
+  template:
+    src: nginx.conf.j2
+    dest: /opt/nginx/conf.d/nginx.conf
+  notify:
+    - reload nginx
+- name: run
+  docker:
+    state: reloaded
+    name: nginx
+    image: "nginx:{{ nginx_version }}"
+    volumes:
+      - /opt/nginx/conf.d:/etc/nginx/conf.d
+      - /opt/nginx/certs:/etc/nginx/certs
+      - /opt/nginx/logs:/var/log/nginx
+    net: host
+    restart_policy: always

--- a/solarnet/roles/nginx/tasks/main.yml
+++ b/solarnet/roles/nginx/tasks/main.yml
@@ -1,4 +1,11 @@
 ---
+# XXX: migration
+- name: stop old container
+  docker:
+    name: ipfs_gateway_proxy
+    image: "nginx:{{ nginx_version }}"
+    state: stopped
+
 - name: create config directory
   file: path=/opt/nginx/conf.d state=directory
 - name: install config

--- a/solarnet/roles/nginx/templates/nginx.conf.j2
+++ b/solarnet/roles/nginx/templates/nginx.conf.j2
@@ -1,0 +1,1 @@
+server_names_hash_bucket_size 64;

--- a/solarnet/roles/nginx/vars/main.yml
+++ b/solarnet/roles/nginx/vars/main.yml
@@ -1,0 +1,2 @@
+---
+nginx_version: 1.9.3

--- a/solarnet/roles/node_exporter/tasks/main.yml
+++ b/solarnet/roles/node_exporter/tasks/main.yml
@@ -37,11 +37,8 @@
   shell: "echo {{ node_exporter_ref }} > /opt/node_exporter.ref"
   when: "node_exporter_ref_present.rc != 0"
 
-- file: path=/containers/ipfs_gateway_proxy state=directory
-- file: path=/containers/ipfs_gateway_proxy/conf.d state=directory
+- file: path=/opt/nginx/conf.d state=directory
 - template:
     src: nginx_node_exporter.conf.j2
-    dest: /containers/ipfs_gateway_proxy/conf.d/node_exporter.conf
-  register: nginx_node_exporter
-- command: docker exec ipfs_gateway_proxy /etc/init.d/nginx reload
-  when: nginx_node_exporter.changed
+    dest: /opt/nginx/conf.d/node_exporter.conf
+  notify: reload nginx

--- a/solarnet/solarnet.yml
+++ b/solarnet/solarnet.yml
@@ -11,7 +11,7 @@
 
 - hosts: gateway
   vars:
-    gateway_group: all
+    gateway_group: gateway
   pre_tasks:
     - include_vars: secrets.yml
   handlers:
@@ -32,7 +32,7 @@
     - pluto
     - neptune
   vars:
-    gateway_group: all
+    gateway_group: gateway
   pre_tasks:
     - include_vars: secrets.yml
   roles:

--- a/solarnet/solarnet.yml
+++ b/solarnet/solarnet.yml
@@ -20,20 +20,13 @@
     - ipfs
     - ipfs_gateway
 
-- hosts: pluto
-  pre_tasks:
-  - include_vars: secrets.yml
-  handlers:
-  - include: roles/nginx/handlers/main.yml
-  roles:
-  - metrics
-
-- hosts:
-    - pluto
-    - neptune
+- hosts: scruffy
   vars:
     gateway_group: gateway
   pre_tasks:
     - include_vars: secrets.yml
+  handlers:
+    - include: roles/nginx/handlers/main.yml
   roles:
+    - metrics
     - pinbot

--- a/solarnet/solarnet.yml
+++ b/solarnet/solarnet.yml
@@ -1,20 +1,30 @@
 ---
 - hosts: all
-  vars:
-    gateway_group: all
   pre_tasks:
   - include_vars: secrets.yml
   roles:
     - common
     - docker
     - cjdns
+    - nginx
+    - node_exporter
+
+- hosts: gateway
+  vars:
+    gateway_group: all
+  pre_tasks:
+    - include_vars: secrets.yml
+  handlers:
+    - include: roles/nginx/handlers/main.yml
+  roles:
     - ipfs
     - ipfs_gateway
-    - node_exporter
 
 - hosts: pluto
   pre_tasks:
   - include_vars: secrets.yml
+  handlers:
+  - include: roles/nginx/handlers/main.yml
   roles:
   - metrics
 


### PR DESCRIPTION
Since I added the first non-gateway host (scruffy), I needed to have nginx decoupled from IPFS.

Every host runs cjdns, nginx, and prometheus' node_exporter. The gateway hosts simply add vhosts to the nginx config.