### PR TITLE
solarnet: move pinbot to new host called willie

### DIFF
--- a/solarnet/hosts
+++ b/solarnet/hosts
@@ -11,8 +11,8 @@ mercury     ansible_ssh_host=178.62.61.185
 ; managed by whyrusleeping
 ; mars        ansible_ssh_host=104.131.131.82
 
-[util]
+[metrics]
 scruffy     ansible_ssh_host=104.131.3.162
 
-; TODO: backup for scruffy
-; willie      ansible_ssh_host=todo
+[util]
+willie      ansible_ssh_host=46.101.230.158

--- a/solarnet/solarnet.yml
+++ b/solarnet/solarnet.yml
@@ -20,7 +20,7 @@
     - ipfs
     - ipfs_gateway
 
-- hosts: scruffy
+- hosts: metrics
   vars:
     gateway_group: gateway
   pre_tasks:
@@ -29,4 +29,13 @@
     - include: roles/nginx/handlers/main.yml
   roles:
     - metrics
+
+- hosts: util
+  vars:
+    gateway_group: gateway
+  pre_tasks:
+    - include_vars: secrets.yml
+  handlers:
+    - include: roles/nginx/handlers/main.yml
+  roles:
     - pinbot


### PR DESCRIPTION
So that pinbot builds don't run out of memory, which is eaten up by Prometheus, see #56 

License: MIT
Signed-off-by: Lars Gierth <larsg@systemli.org>