### PR TITLE
secrets: rework how we store secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+solarnet.key

--- a/solarnet/.gitignore
+++ b/solarnet/.gitignore
@@ -1,2 +1,3 @@
 venv/
-secrets.yml
+secrets/
+secrets_plaintext/

--- a/solarnet/README.md
+++ b/solarnet/README.md
@@ -2,6 +2,7 @@
 
 - [Overview](#overview)
 - [Getting Started](#getting-started)
+- [Secrets](#secrets)
 - [Common Tasks](#common-tasks)
 - [Troubleshooting](#troubleshooting)
 - [Monitoring](#monitoring)
@@ -63,6 +64,32 @@ $ . venv/bin/activate
 # see if it works
 (venv)$ which ansible
 (venv)$ ansible all -a 'whoami'
+```
+
+## Secrets
+
+IPFS and cjdns private keys, SSL certificates, and cjdns peering credentials,
+are tracked by Git in a secret repository, in encrypted form.
+We need to decrypt them for usage, and encrypt them for committing changes.
+
+```sh
+# initialize and decrypt
+$ git clone https://example.net/secrets.git secrets/
+$ echo "the-key" > ../solarnet.key
+$ ./secrets.sh -d
+
+# make changes and encrypt
+$ vim secrets_plaintext/secrets.yml
+$ ./secrets.sh -e
+$ cd secrets/
+$ git add secrets.yml
+$ git commit -m 'Add some password or so'
+```
+
+You can also pipe the key instead of writing it to a file:
+
+```sh
+$ echo "the-key" | ./secrets.sh -d
 ```
 
 ## Common Tasks

--- a/solarnet/secrets.sh
+++ b/solarnet/secrets.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+keyfile="../solarnet.key"
+if [ -f $keyfile ] ; then
+  echo "Reading key from $keyfile"
+  key=$(cat $keyfile)
+else
+  echo "Reading key from stdin"
+  read key
+fi
+
+if [ "$1" = "-e" ] ; then
+  cd secrets_plaintext/
+  for f in * ; do
+    echo "secrets_plaintext/$f => secrets/$f"
+    cat $f | senc -e -k "$key" > ../secrets/$f
+  done
+elif [ "$1" = "-d" ] ; then
+  mkdir -p secrets_plaintext/
+  cd secrets/
+  for f in * ; do
+    echo "secrets/$f => secrets_plaintext/$f"
+    cat $f | senc -d -k "$key" > ../secrets_plaintext/$f
+  done
+else
+  echo "usage: echo \$key | ./secrets.sh -e|-d"
+fi

--- a/solarnet/solarnet.yml
+++ b/solarnet/solarnet.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: all
   pre_tasks:
-  - include_vars: secrets.yml
+    - include_vars: secrets_plaintext/secrets.yml
   roles:
     - common
     - docker
@@ -13,7 +13,7 @@
   vars:
     gateway_group: gateway
   pre_tasks:
-    - include_vars: secrets.yml
+    - include_vars: secrets_plaintext/secrets.yml
   handlers:
     - include: roles/nginx/handlers/main.yml
   roles:
@@ -24,7 +24,7 @@
   vars:
     gateway_group: gateway
   pre_tasks:
-    - include_vars: secrets.yml
+    - include_vars: secrets_plaintext/secrets.yml
   handlers:
     - include: roles/nginx/handlers/main.yml
   roles:
@@ -34,7 +34,7 @@
   vars:
     gateway_group: gateway
   pre_tasks:
-    - include_vars: secrets.yml
+    - include_vars: secrets_plaintext/secrets.yml
   handlers:
     - include: roles/nginx/handlers/main.yml
   roles:


### PR DESCRIPTION
From the updated readme:

IPFS and cjdns private keys, SSL certificates, and cjdns peering credentials,
are tracked by Git in a secret repository, in encrypted form.
We need to decrypt them for usage, and encrypt them for committing changes.

```sh
# initialize and decrypt
$ git clone https://example.net/secrets.git secrets/
$ echo "the-key" > ../solarnet.key
$ ./secrets.sh -d

# make changes and encrypt
$ vim secrets_plaintext/secrets.yml
$ ./secrets.sh -e
$ cd secrets/
$ git add secrets.yml
$ git commit -m 'Add some password or so'
```

You can also pipe the key instead of writing it to a file:

```sh
$ echo "the-key" | ./secrets.sh -d
```