### PR TITLE
solarnet: add storage hosts sirius and pollux

### DIFF
--- a/solarnet/hosts
+++ b/solarnet/hosts
@@ -16,3 +16,7 @@ scruffy     ansible_ssh_host=104.131.3.162
 
 [util]
 willie      ansible_ssh_host=46.101.230.158
+
+[storage]
+pollux      ansible_ssh_host=5.9.59.34
+sirius      ansible_ssh_host=199.229.254.55

--- a/solarnet/solarnet.yml
+++ b/solarnet/solarnet.yml
@@ -20,6 +20,12 @@
     - ipfs
     - ipfs_gateway
 
+- hosts: storage
+  handlers:
+    - include: roles/nginx/handlers/main.yml
+  roles:
+    - ipfs
+
 - hosts: metrics
   vars:
     gateway_group: gateway


### PR DESCRIPTION
I take name suggestions, right now it's storage1.i.ipfs.io