### PR TITLE
Make /ipfs and /ipns work with self-hosted ipfs.io

### DIFF
--- a/solarnet/roles/ipfs_gateway/templates/nginx_ipfs_gateway.conf.j2
+++ b/solarnet/roles/ipfs_gateway/templates/nginx_ipfs_gateway.conf.j2
@@ -85,6 +85,7 @@ server {
     location / {
         proxy_pass http://gateway;
         proxy_set_header Host $proxyhost;
+        proxy_read_timeout 1800s;
     }
 
     access_log /var/log/nginx/default.access.log;

--- a/solarnet/roles/ipfs_gateway/templates/nginx_ipfs_gateway.conf.j2
+++ b/solarnet/roles/ipfs_gateway/templates/nginx_ipfs_gateway.conf.j2
@@ -76,9 +76,15 @@ server {
 
     resolver 8.8.8.8 8.8.4.4;
 
+    set $hosturi $host$uri;
+    set $proxyhost "";
+    if ($hosturi !~ "^ipfs\.io/(ipfs|ipns|api)(/|$)") {
+        set $proxyhost $host;
+    }
+
     location / {
         proxy_pass http://gateway;
-        proxy_set_header Host $host;
+        proxy_set_header Host $proxyhost;
     }
 
     access_log /var/log/nginx/default.access.log;

--- a/solarnet/roles/nginx/handlers/main.yml
+++ b/solarnet/roles/nginx/handlers/main.yml
@@ -1,3 +1,3 @@
 ---
 - name: reload nginx
-  command: docker exec nginx /etc/init.d/nginx reload
+  shell: "docker exec nginx sh -c '/etc/init.d/nginx configtest && /etc/init.d/nginx reload'"


### PR DESCRIPTION
If the host is ipfs.io, and the request is for /ipfs or /ipns,
we don't pass the Host header on to the gateway,
so that IPNSHostnameOption doesn't trigger,
and the /ipfs and /ipns request can succeed.

For all other requests with a Host header and TXT record,
/ipfs and /ipns are not present.