### PR TITLE
solarnet: add users playbook

### DIFF
--- a/solarnet/secrets.yml.example
+++ b/solarnet/secrets.yml.example
@@ -3,6 +3,12 @@
 authorized_keys:
   - "ssh-ed25519 AAAACfoobar1234 some-name"
 
+users:
+  - name: alice
+    uid: 1040
+    home: /home/alice
+    key: ssh-ed25519 AAAAndthepublickey
+
 # the cryptographic and network identity of each host with the cjdns role
 # each of them will also be allowed to access /debug on others.
 cjdns_identities:

--- a/solarnet/users.yml
+++ b/solarnet/users.yml
@@ -1,0 +1,18 @@
+---
+- hosts: storage
+  pre_tasks:
+    - include_vars: secrets_plaintext/secrets.yml
+  tasks:
+    - user:
+        name: "{{ item.name }}"
+        uid: "{{ item.uid }}"
+        home: "{{ item.home }}"
+        group: users
+        state: present
+      with_items: "{{ users }}"
+    - authorized_key:
+        user: "{{ item.name }}"
+        key: "{{ item.key }}"
+        state: present
+        exclusive: yes
+      with_items: "{{ users }}"


### PR DESCRIPTION
@rht @davidar @mikolalysenko you should all have access to pollux.i.ipfs.io and sirius.i.ipfs.io, using your github handle as the username.

If you want to run an IPFS node, please do so, but make sure to disable dialing local addresses, as describe here: https://github.com/ipfs/go-ipfs/issues/1226#issuecomment-120494604
Otherwise we get alerts from the hoster, and the host gets shut down if we don't react quickly enough.

There is one IPFS node running in a docker container which uses ports 4001, 5001, and 8080. You should be able to use that with the regular IPFS CLI, but in any case you can run your own node.

Any questions? We can amend that setup to whatever seems more appropriate.