### PR TITLE
Monitoring fixes

### DIFF
--- a/solarnet/metrics.yml
+++ b/solarnet/metrics.yml
@@ -9,7 +9,9 @@
 
 - hosts: metrics
   vars:
-    gateway_group: gateway
+    node_targets: "{{ cjdns_identities.keys() }}"
+    gateway_targets: "{{ groups.gateway }}"
+    storage_targets: "{{ groups.storage }}"
   pre_tasks:
     - include_vars: secrets_plaintext/secrets.yml
   handlers:

--- a/solarnet/roles/docker/tasks/main.yml
+++ b/solarnet/roles/docker/tasks/main.yml
@@ -35,3 +35,9 @@
     state: present
   notify:
     - restart docker
+
+- name: docker service
+  service:
+    name: docker
+    enabled: yes
+    state: started

--- a/solarnet/roles/docker/tasks/main.yml
+++ b/solarnet/roles/docker/tasks/main.yml
@@ -23,7 +23,7 @@
 # XXX migration
 - lineinfile:
     dest: /etc/default/docker
-    line: 'DOCKER_OPTS=--log-driver=none'
+    line: 'DOCKER_OPTS="--log-driver=none"'
     state: absent
   notify:
     - restart docker

--- a/solarnet/roles/metrics/files/Dockerfile
+++ b/solarnet/roles/metrics/files/Dockerfile
@@ -24,6 +24,7 @@ WORKDIR    /prometheus
 ENTRYPOINT [ "/bin/prometheus" ]
 CMD        [ "-config.file=/etc/prometheus/prometheus.yml", \
              "-storage.local.path=/prometheus", \
+             "-storage.local.memory-chunks=512288", \
              "-web.path-prefix=/prometheus", \
              "-web.console.libraries=/etc/prometheus/console_libraries", \
              "-web.console.templates=/etc/prometheus/consoles" ]

--- a/solarnet/roles/metrics/templates/prometheus.yml.j2
+++ b/solarnet/roles/metrics/templates/prometheus.yml.j2
@@ -6,22 +6,28 @@ global:
     monitor: '{{ ansible_hostname }}'
 
 scrape_configs:
-  - job_name: 'ipfs'
+  - job_name: 'gateway'
     scrape_interval: 5s
     scrape_timeout: 10s
     metrics_path: '/debug/metrics/prometheus'
     target_groups:
       - targets:
-{% for hostname in groups[gateway_group] %}
+{% for hostname in gateway_targets %}
         - '[{{ cjdns_identities[hostname].ipv6 }}]:5001'
 {% endfor %}
 
-  - job_name: 'node'
-    scrape_interval: 5s
-    scrape_timeout: 10s
+  - job_name: 'storage'
+    metrics_path: '/debug/metrics/prometheus'
+    target_groups:
+      - targets:
+{% for hostname in storage_targets %}
+        - '[{{ cjdns_identities[hostname].ipv6 }}]:5001'
+{% endfor %}
+
+  - job_name: 'host'
     metrics_path: '/metrics'
     target_groups:
       - targets:
-{% for hostname in cjdns_identities.keys() %}
+{% for hostname in node_targets %}
         - '[{{ cjdns_identities[hostname].ipv6 }}]:9100'
 {% endfor %}

--- a/solarnet/roles/metrics/templates/prometheus.yml.j2
+++ b/solarnet/roles/metrics/templates/prometheus.yml.j2
@@ -1,14 +1,11 @@
 ---
 global:
   scrape_interval:     15s
+  scrape_timeout:      10s
   evaluation_interval: 15s
-  labels:
-    monitor: '{{ ansible_hostname }}'
 
 scrape_configs:
   - job_name: 'gateway'
-    scrape_interval: 5s
-    scrape_timeout: 10s
     metrics_path: '/debug/metrics/prometheus'
     target_groups:
       - targets:

--- a/solarnet/roles/node_exporter/templates/upstart_node_exporter.conf.j2
+++ b/solarnet/roles/node_exporter/templates/upstart_node_exporter.conf.j2
@@ -6,4 +6,4 @@ stop on starting rc RUNLEVEL=[016]
 respawn
 respawn limit unlimited
 
-exec /usr/bin/node_exporter --web.listen-address="127.0.0.1:9100"
+exec /usr/bin/node_exporter --web.listen-address="127.0.0.1:9100" -collectors.enabled=filesystem,netdev


### PR DESCRIPTION
commit 91754c7dd3ead43f8fe3802b66a6fd7e49efdc7e
Author: Lars Gierth <larsg@systemli.org>
Date:   Mon Sep 21 19:42:31 2015 +0200

```
    docker: make sure docker is enabled and started
    
    License: MIT
    Signed-off-by: Lars Gierth <larsg@systemli.org>
```

commit bf89890010d2e71efca1db6d2a705f2bd931e2d2
Author: Lars Gierth <larsg@systemli.org>
Date:   Mon Sep 21 19:42:12 2015 +0200

```
    docker: fix --log-driver migration
    
    License: MIT
    Signed-off-by: Lars Gierth <larsg@systemli.org>
```

commit fc872adf1bca9824de58ea8b6709d110c64a14c6
Author: Lars Gierth <larsg@systemli.org>
Date:   Mon Sep 21 19:41:18 2015 +0200

```
    prometheus: performance tuning
    
    - scrape less often
    - removed unused monitor label
    - use less RAM, we were running out of it constantly
    
    License: MIT
    Signed-off-by: Lars Gierth <larsg@systemli.org>
```

commit 0e531686b5923302741e34d8a7e20dc2540541a6
Author: Lars Gierth <larsg@systemli.org>
Date:   Mon Sep 21 19:37:25 2015 +0200

```
    prometheus: clean up target host definitions
    
    License: MIT
    Signed-off-by: Lars Gierth <larsg@systemli.org>
```

commit 20783a0f59f2ecac99859931493955e6dd7d0a73
Author: Lars Gierth <larsg@systemli.org>
Date:   Mon Sep 21 19:34:25 2015 +0200

```
    prometheus: only collect filesystem and netdev metrics
    
    We don't need the others, and they eat up RAM and diskspace.
    
    License: MIT
    Signed-off-by: Lars Gierth <larsg@systemli.org>
```
