### PR TITLE
Alexandria peering

### DIFF
--- a/solarnet/cjdns.yml
+++ b/solarnet/cjdns.yml
@@ -1,0 +1,6 @@
+---
+- hosts: all
+  pre_tasks:
+    - include_vars: secrets_plaintext/secrets.yml
+  roles:
+    - cjdns

--- a/solarnet/common.yml
+++ b/solarnet/common.yml
@@ -7,5 +7,4 @@
   roles:
     - common
     - docker
-    - cjdns
     - nginx

--- a/solarnet/peering.sh
+++ b/solarnet/peering.sh
@@ -35,9 +35,11 @@ password=$cjdns_authorized_passwords_password
 
 for host in $hosts; do
   eval "pubkey=\$cjdns_identities_$host""_public_key"
+  ipAddr=$(ansible $host -m debug -a 'var=ansible_ssh_host' -o | cut -d'>' -f 3 | jq -r '.var.ansible_ssh_host')
 
-  [ -z $pubkey ] || cat << JSON
-    "$host.i.ipfs.io:$port": {
+  [ -z "$pubkey" ] || cat << JSON
+    "$ipAddr:$port": {
+        "peerName": "$host.i.ipfs.io",
         "publicKey": "$pubkey",
         "password": "$password"
     },

--- a/solarnet/peering.sh
+++ b/solarnet/peering.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 
-# Builds a cjdroute.conf snippet for peering with all nodes in secrets.yml
-#
-# Usage:
-#   ./peering.sh
+function usage {
+  echo "Builds a cjdroute.conf snippet for peering with the specified ansible hosts"
+  echo
+  echo "Usage:"
+  echo "  ./peering.sh <pattern>"
+  echo "  ./peering.sh all"
+  echo "  ./peering.sh gateway"
+  echo "  ./peering.sh pluto:earth"
+}
+
+[ -z "$1" ] && usage && exit 1
 
 # Primitive YAML parser for Bash, https://stackoverflow.com/a/21189044/2068670
 # By Stefan Farestam, updated for basic YAML array support
@@ -29,9 +36,9 @@ function parse_yaml {
 eval $(parse_yaml roles/cjdns/vars/main.yml)
 eval $(parse_yaml secrets_plaintext/secrets.yml)
 
-hosts=$(ansible all --list-hosts)
+hosts=$(ansible $1 --list-hosts)
 port=$(echo $cjdns_udp_interfaces_bind | cut -d':' -f2)
-password=$cjdns_authorized_passwords_password
+password="$cjdns_authorized_passwords_password"
 
 for host in $hosts; do
   eval "pubkey=\$cjdns_identities_$host""_public_key"

--- a/solarnet/peering.sh
+++ b/solarnet/peering.sh
@@ -1,16 +1,17 @@
 #!/usr/bin/env bash
 
 function usage {
-  echo "Builds a cjdroute.conf snippet for peering with the specified ansible hosts"
+  echo "Builds a cjdroute.conf snippet for peering with the specified ansible hosts, using the specified password"
   echo
   echo "Usage:"
-  echo "  ./peering.sh <pattern>"
-  echo "  ./peering.sh all"
-  echo "  ./peering.sh gateway"
-  echo "  ./peering.sh pluto:earth"
+  echo "  ./peering.sh <pattern> <password-name>"
+  echo "  ./peering.sh all solarnet"
+  echo "  ./peering.sh gateway alexandria"
+  echo "  ./peering.sh pluto:earth protocol"
 }
 
 [ -z "$1" ] && usage && exit 1
+[ -z "$2" ] && usage && exit 1
 
 # Primitive YAML parser for Bash, https://stackoverflow.com/a/21189044/2068670
 # By Stefan Farestam, updated for basic YAML array support
@@ -38,7 +39,9 @@ eval $(parse_yaml secrets_plaintext/secrets.yml)
 
 hosts=$(ansible $1 --list-hosts)
 port=$(echo $cjdns_udp_interfaces_bind | cut -d':' -f2)
-password="$cjdns_authorized_passwords_password"
+
+eval "password=\$cjdns_authorized_passwords""_$2"
+[ -z "$password" ] && echo "unknown password: $2" && exit 1
 
 for host in $hosts; do
   eval "pubkey=\$cjdns_identities_$host""_public_key"

--- a/solarnet/roles/cjdns/templates/cjdroute.conf.j2
+++ b/solarnet/roles/cjdns/templates/cjdroute.conf.j2
@@ -23,8 +23,11 @@
         ]
     },
     "authorizedPasswords": [
-{% for password in cjdns_authorized_passwords %}
-        { "password": "{{ password.password }}" },
+{% for user in cjdns_authorized_passwords.keys() %}
+        {
+            "user": "{{ user }}",
+            "password": "{{ cjdns_authorized_passwords[user] }}"
+        },
 {% endfor %}
     ],
     "router": {

--- a/solarnet/roles/cjdns/templates/cjdroute.conf.j2
+++ b/solarnet/roles/cjdns/templates/cjdroute.conf.j2
@@ -13,7 +13,8 @@
 {% for peer in interface.peers %}
                 "{{ peer.connect_to }}": {
                     "publicKey": "{{ peer.public_key }}",
-                    "password": "{{ peer.password }}"
+                    "password": "{{ peer.password }}",
+                    "peerName": "{{ peer.peer_name }}"
                 },
 {% endfor %}
             }

--- a/solarnet/roles/cjdns/vars/main.yml
+++ b/solarnet/roles/cjdns/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-cjdns_ref: a7e050259bb845b6f8c3b2d1626a492a44a900b0
+cjdns_ref: 2a0f3205084e54531112164dadc917191cd22ab1
 cjdns_admin_address: 127.0.0.1
 cjdns_admin_port: 11234
 cjdns_admin_password: NONE

--- a/solarnet/secrets.yml.example
+++ b/solarnet/secrets.yml.example
@@ -34,7 +34,7 @@ cjdns_udp_interfaces:
 
 # passwords for incoming peerings
 cjdns_authorized_passwords:
-  - password: some-reasonably-strong-password
+  - jane: some-reasonably-strong-password
 
 # additional hosts allowed to access /debug
 metrics_whitelist:

--- a/solarnet/secrets.yml.example
+++ b/solarnet/secrets.yml.example
@@ -24,11 +24,13 @@ cjdns_udp_interfaces:
       - connect_to: [1234::56]:65432
         public_key: the-peers-public-key.k
         password: the-password
+        peer_name: the-human-readable-peer
   - bind: 0.0.0.0:54321
     peers:
       - connect_to: 1.2.3.4:65432
         public_key: the-peers-public-key.k
         password: the-password
+        peer_name: the-human-readable-peer
 
 # passwords for incoming peerings
 cjdns_authorized_passwords:


### PR DESCRIPTION
commit 2e31e24392e70b0c15217b2ea79582bc623c2698
Author: Lars Gierth <larsg@systemli.org>
Date:   Mon Sep 28 04:05:24 2015 +0200

```
    cjdns: make peering.sh aware of different passwords
```

commit 65a0308c63dfc9c33278324aabe05bd380eaa5c3
Author: Lars Gierth <larsg@systemli.org>
Date:   Mon Sep 28 03:12:52 2015 +0200

```
    cjdns: update to latest hyperboria:master
```

commit 47724d636c932422a806f7438a63857ee9265e09
Author: Lars Gierth <larsg@systemli.org>
Date:   Mon Sep 28 03:11:42 2015 +0200

```
    cjdns: give peering.sh a host pattern argument
    
    We might want to get peering details
    for only a handful of hosts.
```

commit f016f61784cc054bc4fa51903946ffc5ff0f963d
Author: Lars Gierth <larsg@systemli.org>
Date:   Mon Sep 28 03:09:50 2015 +0200

```
    cjdns: make use of peerName
    
    Makes for more meaningful peerstats.
    
    Try /opt/cjdns/tools/peerStats :)
```

commit 183177c32bfe81f2f5baa25e931e10434a26bd2b
Author: Lars Gierth <larsg@systemli.org>
Date:   Mon Sep 28 03:08:04 2015 +0200

```
    solarnet: move cjdns to its own playbook
```