### PR TITLE
gateway: add /refs/*

### DIFF
--- a/solarnet/roles/ipfs_gateway/templates/nginx_ipfs_gateway.conf.j2
+++ b/solarnet/roles/ipfs_gateway/templates/nginx_ipfs_gateway.conf.j2
@@ -76,15 +76,22 @@ server {
 
     resolver 8.8.8.8 8.8.4.4;
 
-    set $hosturi $host$uri;
-    set $proxyhost "";
-    if ($hosturi !~ "^(h\.)?ipfs\.io/(ipfs|ipns|api)(/|$)") {
-        set $proxyhost $host;
+    location /refs/ {
+        rewrite "^/refs(/.*)$" $1 break;
+        proxy_set_header Host refs.ipfs.io;
+        proxy_pass http://gateway;
+        proxy_read_timeout 1800s;
+    }
+
+    location ~ "^/(ipfs|ipns|api)(/|$)" {
+        proxy_set_header Host "";
+        proxy_pass http://gateway;
+        proxy_read_timeout 1800s;
     }
 
     location / {
+        proxy_set_header Host $host;
         proxy_pass http://gateway;
-        proxy_set_header Host $proxyhost;
         proxy_read_timeout 1800s;
     }
 


### PR DESCRIPTION
Rewrites requests for `/refs/a/b/c` to `c.b.a.refs.ipfs.io`.

Also replaces conditionals with location directives,
which are evaluated more efficiently.

Part of the gateway-dmca-denylist thing: https://github.com/ipfs/go-ipfs/pull/1551 https://github.com/ipfs/gateway-dmca-denylist