### PR TITLE
Prepare hsts config for preload

### DIFF
--- a/solarnet/roles/ipfs_gateway/templates/nginx_ipfs_gateway.conf.j2
+++ b/solarnet/roles/ipfs_gateway/templates/nginx_ipfs_gateway.conf.j2
@@ -64,7 +64,7 @@ server {
     ssl_prefer_server_ciphers on;
 
     # HSTS (ngx_http_headers_module is required) (15768000 seconds = 6 months)
-    add_header Strict-Transport-Security max-age=15768000;
+    add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload"
 
     # OCSP Stapling ---
     # fetch OCSP records from URL in ssl_certificate and cache them


### PR DESCRIPTION
This enforces https on ipfs.io and all subdomains. After that, the site qualifies for inclusion in the preload list: https://hstspreload.appspot.com/
