### PR TITLE
golang1.5 for IPFS and Pinbot

### DIFF
--- a/solarnet/roles/ipfs/files/Dockerfile
+++ b/solarnet/roles/ipfs/files/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.5.1
 MAINTAINER Lars Gierth <larsg@systemli.org>
 
 # This IPFS repo should be copied into ./go-ipfs
-ADD go-ipfs /go/src/github.com/ipfs/go-ipfs
+ADD . /go/src/github.com/ipfs/go-ipfs
 
 RUN cd /go/src/github.com/ipfs/go-ipfs/cmd/ipfs && go install
 

--- a/solarnet/roles/ipfs/files/Dockerfile
+++ b/solarnet/roles/ipfs/files/Dockerfile
@@ -1,5 +1,5 @@
-FROM golang:1.4
-MAINTAINER Brian Tiger Chow <btc@perfmode.com>
+FROM golang:1.5.1
+MAINTAINER Lars Gierth <larsg@systemli.org>
 
 # This IPFS repo should be copied into ./go-ipfs
 ADD go-ipfs /go/src/github.com/ipfs/go-ipfs

--- a/solarnet/roles/ipfs/tasks/main.yml
+++ b/solarnet/roles/ipfs/tasks/main.yml
@@ -1,23 +1,22 @@
 ---
 # build the docker image, if needed
-- shell: "docker images -a | grep {{ ipfs_ref }}"
+- shell: "cat /opt/ipfs.ref | grep {{ ipfs_ref }}"
   ignore_errors: true
-  register: ipfs_image_present
-- file:
-    path: /ipfs_build
-    state: directory
-  when: "ipfs_image_present.rc != 0"
-- copy:
-    src: Dockerfile
-    dest: /ipfs_build/Dockerfile
-  when: "ipfs_image_present.rc != 0"
+  register: ipfs_ref_present
 - git:
     repo: https://github.com/ipfs/go-ipfs.git
-    dest: /ipfs_build/go-ipfs
+    dest: /opt/ipfs/src
     version: "{{ ipfs_ref }}"
-  when: "ipfs_image_present.rc != 0"
-- shell: "docker build -t ipfs:{{ ipfs_ref }} /ipfs_build"
-  when: "ipfs_image_present.rc != 0"
+    force: yes
+  when: "ipfs_ref_present.rc != 0"
+- copy:
+    src: Dockerfile
+    dest: /opt/ipfs/src/Dockerfile
+  when: "ipfs_ref_present.rc != 0"
+- shell: "docker build -t ipfs:{{ ipfs_ref }} /opt/ipfs/src"
+  when: "ipfs_ref_present.rc != 0"
+- shell: "echo {{ ipfs_ref }} > /opt/ipfs.ref"
+  when: "ipfs_ref_present.rc != 0"
 
 # generate ipfs repo
 - command: "docker run -i -v /ipfs/ipfs_master:/ipfs ipfs:{{ ipfs_ref }} sh -c 'IPFS_PATH=/ipfs/repo ipfs init'"

--- a/solarnet/roles/pinbot/files/Dockerfile
+++ b/solarnet/roles/pinbot/files/Dockerfile
@@ -1,18 +1,14 @@
-FROM alpine:3.2
+FROM golang:1.5.1
 MAINTAINER Lars Gierth <larsg@systemli.org>
 
 ENV GOPATH=/go \
     REPO_PATH=github.com/whyrusleeping/pinbot
 COPY . $GOPATH/src/$REPO_PATH
 
-RUN apk add --update go git \
-    && apk add -u musl \
-    && go get github.com/whyrusleeping/hellabot \
+RUN go get github.com/whyrusleeping/hellabot \
     && go get github.com/whyrusleeping/ipfs-shell \
     && cd $GOPATH/src/$REPO_PATH \
-    && go build -o /bin/pinbot $REPO_PATH \
-    && rm -rf $GOPATH /var/cache/apk/* \
-    && apk del --purge go git
+    && go build -o /bin/pinbot $REPO_PATH
 
 VOLUME     [ "/pinbot" ]
 WORKDIR    /pinbot


### PR DESCRIPTION
commit 253d9a4781904c6ed4afd9e4cece1b40ed278a8d
Author: Lars Gierth <larsg@systemli.org>
Date:   Fri Oct 23 03:17:04 2015 +0200

    pinbot: base on golang:1.5.1 image
    
    Alpine has go1.5 in their community repos,
    but I have no idea how to make use of it.
    
    We were using Alpine here to keep the image size down,
    but these images never hit the wire anyhow.
    
    License: MIT
    Signed-off-by: Lars Gierth <larsg@systemli.org>

commit 8e87963f504c655d529cbf7367d0922df7be0627
Author: Lars Gierth <larsg@systemli.org>
Date:   Fri Oct 23 03:48:52 2015 +0200

    ipfs: base on golang:1.5.1 image
    
    License: MIT
    Signed-off-by: Lars Gierth <larsg@systemli.org>

commit 1e75827d0f185f0b1359381389cbdf1dadc01d24
Author: Lars Gierth <larsg@systemli.org>
Date:   Fri Oct 23 03:49:44 2015 +0200

    ipfs: use ipfs.ref file to trigger rebuilds
    
    This makes it consistent with the other services.
    
    License: MIT
    Signed-off-by: Lars Gierth <larsg@systemli.org>
