### PR TITLE
secrets: move encryption key to a safer location

### DIFF
--- a/solarnet/README.md
+++ b/solarnet/README.md
@@ -72,7 +72,7 @@ You can base your own secret repository off `secrets.yml.example`.
 ```sh
 # initialize and decrypt
 $ git clone https://github.com/protocol/infrastructure-secrets.git secrets/
-$ echo "the-key" > ../solarnet.key
+$ echo "the-key" > $HOME/.protocol/solarnet.key
 $ ./secrets.sh -d
 
 # make changes and encrypt

--- a/solarnet/secrets.sh
+++ b/solarnet/secrets.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-keyfile="../solarnet.key"
+keyfile="$HOME/.protocol/solarnet.key"
 if [ -f $keyfile ] ; then
   echo "Reading key from $keyfile"
   key=$(cat $keyfile)


### PR DESCRIPTION
It should now be put into `$HOME/.protocol/solarnet.key` @whyrusleeping @jbenet 

I wanna do it similarly with dnslink-deploy and the Digitalocean key @RichardLitt 