### PR TITLE
ipfs: automatic GC

### DIFF
--- a/solarnet/hosts
+++ b/solarnet/hosts
@@ -1,12 +1,12 @@
 [gateway]
-pluto       ansible_ssh_host=104.236.179.241 ipfs_ref=b4ab6845ac6cb7e3a107d5fbf6d2a1568deb01b4
-neptune     ansible_ssh_host=104.236.176.52
-uranus      ansible_ssh_host=162.243.248.213
-saturn      ansible_ssh_host=128.199.219.111
-jupiter     ansible_ssh_host=104.236.151.122
-venus       ansible_ssh_host=104.236.76.40
-earth       ansible_ssh_host=178.62.158.247
-mercury     ansible_ssh_host=178.62.61.185
+pluto       ansible_ssh_host=104.236.179.241 ipfs_storage_space=30G ipfs_ref=b4ab6845ac6cb7e3a107d5fbf6d2a1568deb01b4
+neptune     ansible_ssh_host=104.236.176.52 ipfs_storage_space=30G
+uranus      ansible_ssh_host=162.243.248.213 ipfs_storage_space=50G
+saturn      ansible_ssh_host=128.199.219.111 ipfs_storage_space=70G
+jupiter     ansible_ssh_host=104.236.151.122 ipfs_storage_space=70G
+venus       ansible_ssh_host=104.236.76.40 ipfs_storage_space=30G
+earth       ansible_ssh_host=178.62.158.247 ipfs_storage_space=30G
+mercury     ansible_ssh_host=178.62.61.185 ipfs_storage_space=30G
 
 ; managed by whyrusleeping
 ; mars        ansible_ssh_host=104.131.131.82
@@ -18,9 +18,9 @@ phobos      ansible_ssh_host=104.131.3.162
 deimos      ansible_ssh_host=46.101.230.158
 
 [storage]
-pollux      ansible_ssh_host=5.9.59.34
-sirius      ansible_ssh_host=199.229.254.55
-castor      ansible_ssh_host=37.59.33.238 ipfs_ref=b4ab6845ac6cb7e3a107d5fbf6d2a1568deb01b4
+pollux      ansible_ssh_host=5.9.59.34 ipfs_storage_space=2600G
+sirius      ansible_ssh_host=199.229.254.55 ipfs_storage_space=970G
+castor      ansible_ssh_host=37.59.33.238 ipfs_storage_space=6900G ipfs_ref=b4ab6845ac6cb7e3a107d5fbf6d2a1568deb01b4
 
 [dev040]
 pluto

--- a/solarnet/hosts
+++ b/solarnet/hosts
@@ -4,7 +4,7 @@ neptune     ansible_ssh_host=104.236.176.52 ipfs_storage_space=30G
 uranus      ansible_ssh_host=162.243.248.213 ipfs_storage_space=50G
 saturn      ansible_ssh_host=128.199.219.111 ipfs_storage_space=70G
 jupiter     ansible_ssh_host=104.236.151.122 ipfs_storage_space=70G
-venus       ansible_ssh_host=104.236.76.40 ipfs_storage_space=30G
+venus       ansible_ssh_host=104.236.76.40 ipfs_storage_space=30G ipfs_ref=4a1043b207c837b071df400682b1df2cfb2be91e
 earth       ansible_ssh_host=178.62.158.247 ipfs_storage_space=30G
 mercury     ansible_ssh_host=178.62.61.185 ipfs_storage_space=30G
 

--- a/solarnet/roles/ipfs/tasks/main.yml
+++ b/solarnet/roles/ipfs/tasks/main.yml
@@ -35,7 +35,7 @@
     name: ipfs
     image: "ipfs:{{ ipfs_ref }}"
     state: reloaded
-    command: ipfs daemon
+    command: ipfs daemon --enable-gc
     restart_policy: always
     ports:
     - 0.0.0.0:4001:4001

--- a/solarnet/roles/ipfs/templates/config.j2
+++ b/solarnet/roles/ipfs/templates/config.j2
@@ -4,9 +4,12 @@
     "PrivKey": "{{ ipfs_identities[inventory_hostname].private_key }}"
   },
   "Datastore": {
-    "Type": "leveldb",
+    "GCPeriod": "20m",
+    "NoSync": true,
     "Path": "/ipfs/repo/datastore",
-    "NoSync": true
+    "StorageGCWatermark": 90,
+    "StorageMax": "{{ ipfs_storage_space }}",
+    "Type": "leveldb",
   },
   "Addresses": {
     "Swarm": [


### PR DESCRIPTION
Each host gets a couple GB headroom for docker containers/images, logs, and all the usual system stuff.

Doesn't quite seem to work yet: https://github.com/ipfs/go-ipfs/pull/1495#issuecomment-159801962