### PR TITLE
docker: reactivate container logs

### DIFF
--- a/solarnet/roles/docker/tasks/main.yml
+++ b/solarnet/roles/docker/tasks/main.yml
@@ -20,6 +20,20 @@
 - name: "create directory for containers"
   file: path=/containers state=directory
 
+- name: MIGRATION remove bogus config line
+  lineinfile:
+    dest: /etc/default/docker
+    line: DOCKER_OPTS=--log-driver=none
+    state: absent
+  notify:
+    - restart docker
+- name: MIGRATION remove bogus config line no. 2
+  lineinfile:
+    dest: /etc/default/docker
+    line: 'DOCKER_OPTS="$DOCKER_OPTS --log-driver=none"'
+    state: absent
+  notify:
+    - restart docker
 - name: container log rotation
   lineinfile:
     dest: /etc/default/docker

--- a/solarnet/roles/docker/tasks/main.yml
+++ b/solarnet/roles/docker/tasks/main.yml
@@ -20,10 +20,11 @@
 - name: "create directory for containers"
   file: path=/containers state=directory
 
-- name: disable container logs
+- name: container log rotation
   lineinfile:
     dest: /etc/default/docker
-    line: 'DOCKER_OPTS="$DOCKER_OPTS --log-driver=none"'
+    regexp: ^DOCKER_OPTS=
+    line: 'DOCKER_OPTS="$DOCKER_OPTS --log-driver=json-file --log-opt max-size=100m --log-opt max-file=2"'
     state: present
   notify:
     - restart docker


### PR DESCRIPTION
Docker can now rotate these container logs, which have been filling our disks in the past!