### PR TITLE
solarnet: add edge hosts namaka and hiiaka

### DIFF
--- a/solarnet/hosts
+++ b/solarnet/hosts
@@ -24,9 +24,14 @@ castor      ansible_ssh_host=37.59.33.238 ipfs_storage_space=6900G ipfs_ref=2df7
 biham       ansible_ssh_host=188.40.114.11 ipfs_storage_space=16600G ipfs_ref=5bf3a590111c8afcb478bd678e93c5f6451bb600
 nihal       ansible_ssh_host=188.40.116.66 ipfs_storage_space=16600G ipfs_ref=2df7a082051c07bf6a0ba889acf92dd383d857ac
 
+[edge]
+namaka      ansible_ssh_host=fc86:e60a:a9f2:92b0:14bb:cf0b:6ac7:6bc4 ipfs_storage_space=40G ipfs_ref=5bf3a590111c8afcb478bd678e93c5f6451bb600
+hiiaka      ansible_ssh_host=fc34:a1be:f784:e564:fe9a:1f9b:7e40:9ca ipfs_storage_space=40G
+
 [dev040]
 pluto
 castor
 pollux
 biham
 nihal
+namaka

--- a/solarnet/ipfs.yml
+++ b/solarnet/ipfs.yml
@@ -2,6 +2,7 @@
 - hosts:
     - gateway
     - storage
+    - edge
   serial: "25%"
   vars:
     gateway_group: gateway

--- a/solarnet/metrics.yml
+++ b/solarnet/metrics.yml
@@ -13,6 +13,7 @@
     gateway_targets: "{{ groups.gateway }}"
     storage_targets: "{{ groups.storage }}"
     metrics_targets: "{{ groups.metrics }}"
+    edge_targets: "{{ groups.edge }}"
   pre_tasks:
     - include_vars: secrets_plaintext/secrets.yml
   handlers:

--- a/solarnet/roles/cjdns/templates/cjdroute.conf.j2
+++ b/solarnet/roles/cjdns/templates/cjdroute.conf.j2
@@ -20,7 +20,14 @@
             }
         },
 {% endfor %}
-        ]
+        ],
+        "ETHInterface" : [
+        {
+            "beacon": 2,
+            "bind": "eth0",
+            "connectTo": {}
+        }
+    ]
     },
     "authorizedPasswords": [
 {% for user in cjdns_authorized_passwords.keys() %}

--- a/solarnet/roles/metrics/templates/prometheus.yml.j2
+++ b/solarnet/roles/metrics/templates/prometheus.yml.j2
@@ -25,6 +25,16 @@ scrape_configs:
           host: '{{ hostname }}'
 {% endfor %}
 
+  - job_name: 'edge'
+    metrics_path: '/debug/metrics/prometheus'
+    target_groups:
+{% for hostname in edge_targets %}
+      - targets:
+          - '[{{ cjdns_identities[hostname].ipv6 }}]:5001'
+        labels:
+          host: '{{ hostname }}'
+{% endfor %}
+
   - job_name: 'host'
     metrics_path: '/metrics'
     target_groups:


### PR DESCRIPTION
cc @whyrusleeping @diasdavid @dignifiedquire

These two are the NUCs which we had at camp -- I'll bring them to congress too, so they'll finally get some combat experience :)

namaka runs dev040 and is already bootstrapped, while hiiaka will run master. I'm referencing them by their cjdns IP because they don't have a fixed IP address on their own. If we lose connectivity, we'll have to hook up a cable and do link-local SSH.