### PR TITLE
Proxy redirects from IPFS gateway

### DIFF
--- a/solarnet/roles/ipfs_gateway/templates/nginx_ipfs_gateway.conf.j2
+++ b/solarnet/roles/ipfs_gateway/templates/nginx_ipfs_gateway.conf.j2
@@ -96,6 +96,7 @@ server {
         proxy_set_header Host "";
         proxy_set_header X-Ipfs-Gateway-Prefix "";
         proxy_pass http://gateway;
+        proxy_redirect default;
         proxy_read_timeout 1800s;
     }
 


### PR DESCRIPTION
This fixes an issue where relative URLs inside an index.html are resolved incorrectly on gateway.ipfs.io

For reference, compare the behaviour of the same content when accessed with/without a trailing slash:

 - works: http://gateway.ipfs.io/ipfs/QmUA7nCLEDUXGznoRJUmc2P2Yafx9T57iKHNfENoJoW7Ls/
 - doesn't: http://gateway.ipfs.io/ipfs/QmUA7nCLEDUXGznoRJUmc2P2Yafx9T57iKHNfENoJoW7Ls