### PR TITLE
Prometheus metrics from nginx logs

### DIFF
--- a/oldnet/roles/common/tasks/main.yml
+++ b/oldnet/roles/common/tasks/main.yml
@@ -2,7 +2,7 @@
 - authorized_key: 'user=root key="{{ item }}"'
   with_items: "{{ authorized_keys }}"
 - hostname: "name={{ inventory_hostname }}"
-- shell: "apt-get update && apt-get install -y mosh vim htop screen bridge-utils build-essential autoconf libtool bison flex nodejs npm mercurial git sysstat iftop tmux unzip jq gdb"
+- shell: "apt-get update && apt-get install -y mosh vim htop screen bridge-utils build-essential autoconf libtool bison flex nodejs npm mercurial git sysstat iftop tmux unzip jq gdb tree"
 - file:
     src: /usr/bin/nodejs
     path: /usr/bin/node

--- a/oldnet/roles/ipfs/templates/nginx_ipfs.conf.j2
+++ b/oldnet/roles/ipfs/templates/nginx_ipfs.conf.j2
@@ -42,7 +42,7 @@ server {
 
 # api v03x
 server {
-    server_name api.ipfs_v03x.local;
+    server_name api.ipfs-v03x.local;
     access_log /var/log/nginx/access.log mtail;
     listen [{{ cjdns_identities[inventory_hostname].ipv6 }}]:15001;
 
@@ -63,7 +63,7 @@ server {
 
 # gateway v03x
 server {
-    server_name gateway.ipfs_v03x.local;
+    server_name gateway.ipfs-v03x.local;
     access_log /var/log/nginx/access.log mtail;
     listen [{{ cjdns_identities[inventory_hostname].ipv6 }}]:18080;
 

--- a/oldnet/roles/ipfs/templates/nginx_ipfs.conf.j2
+++ b/oldnet/roles/ipfs/templates/nginx_ipfs.conf.j2
@@ -1,6 +1,7 @@
 # api
 server {
     server_name api.ipfs.local;
+    access_log /var/log/nginx/access.log mtail;
     listen [{{ cjdns_identities[inventory_hostname].ipv6 }}]:5001;
 
     location / {
@@ -16,14 +17,12 @@ server {
         proxy_set_header Host $host;
         proxy_read_timeout 1800s;
     }
-
-    access_log /var/log/nginx/api.access.log mtail;
-    error_log /var/log/nginx/api.error.log;
 }
 
 # gateway
 server {
     server_name gateway.ipfs.local;
+    access_log /var/log/nginx/access.log mtail;
     listen [{{ cjdns_identities[inventory_hostname].ipv6 }}]:8080;
 
     location / {
@@ -39,14 +38,12 @@ server {
         proxy_set_header Host $host;
         proxy_read_timeout 1800s;
     }
-
-    access_log /var/log/nginx/gateway.access.log mtail;
-    error_log /var/log/nginx/gateway.error.log;
 }
 
 # api v03x
 server {
-    server_name v03x.api.ipfs.local;
+    server_name api.ipfs_v03x.local;
+    access_log /var/log/nginx/access.log mtail;
     listen [{{ cjdns_identities[inventory_hostname].ipv6 }}]:15001;
 
     location / {
@@ -62,14 +59,12 @@ server {
         proxy_set_header Host $host;
         proxy_read_timeout 1800s;
     }
-
-    access_log /var/log/nginx/api_v03x.access.log mtail;
-    error_log /var/log/nginx/api_v03x.error.log;
 }
 
 # gateway v03x
 server {
-    server_name v03x.gateway.ipfs.local;
+    server_name gateway.ipfs_v03x.local;
+    access_log /var/log/nginx/access.log mtail;
     listen [{{ cjdns_identities[inventory_hostname].ipv6 }}]:18080;
 
     location / {
@@ -85,14 +80,12 @@ server {
         proxy_set_header Host $host;
         proxy_read_timeout 1800s;
     }
-
-    access_log /var/log/nginx/gateway_v03x.access.log mtail;
-    error_log /var/log/nginx/gateway_v03x.error.log;
 }
 
 # multireq
 server {
-    server_name multireq.ipfs.local;
+    server_name multireq.local;
+    access_log /var/log/nginx/access.log mtail;
     listen [{{ cjdns_identities[inventory_hostname].ipv6 }}]:8041;
 
     location / {
@@ -108,7 +101,4 @@ server {
         proxy_set_header Host $host;
         proxy_read_timeout 1800s;
     }
-
-    access_log /var/log/nginx/multireq.access.log mtail;
-    error_log /var/log/nginx/multireq.error.log;
 }

--- a/oldnet/roles/ipfs_gateway/templates/nginx_ipfs_gateway.conf.j2
+++ b/oldnet/roles/ipfs_gateway/templates/nginx_ipfs_gateway.conf.j2
@@ -19,6 +19,7 @@ map $http_host $pool {
 
 server {
     server_name ipfs.io;
+    access_log /var/log/nginx/access.log mtail;
 
     listen 80 default_server;
     listen [::]:80 default_server;
@@ -127,7 +128,4 @@ server {
         proxy_pass_header Server;
         proxy_read_timeout 1800s;
     }
-
-    access_log /var/log/nginx/default.access.log mtail;
-    error_log /var/log/nginx/default.error.log;
 }

--- a/oldnet/roles/metrics/templates/prometheus.yml.j2
+++ b/oldnet/roles/metrics/templates/prometheus.yml.j2
@@ -42,6 +42,25 @@ scrape_configs:
           network: v04x
 {% endfor %}
 
+  - job_name: 'mtail'
+    metrics_path: '/metrics'
+    target_groups:
+{% for hostname in node_targets %}
+      - targets:
+          - '[{{ cjdns_identities[hostname].ipv6 }}]:3903'
+        labels:
+          host: '{{ hostname }}'
+{% endfor %}
+    metric_relabel_configs:
+      - source_labels: [prog]
+        regex: .*
+        action: replace
+        target_label: prog
+      - source_labels: [exported_instance]
+        regex: .*
+        action: replace
+        target_label: exported_instance
+
   - job_name: 'host'
     metrics_path: '/metrics'
     target_groups:

--- a/oldnet/roles/nginx/templates/nginx.conf.j2
+++ b/oldnet/roles/nginx/templates/nginx.conf.j2
@@ -9,3 +9,6 @@ gzip_proxied any;
 log_format mtail '$server_name $remote_addr - $remote_user [$time_local] '
                  '"$request" $status $bytes_sent $request_time '
                  '"$http_referer" "$http_user_agent"';
+
+access_log off;
+error_log /var/log/nginx/error.log warn;

--- a/oldnet/roles/nginx/templates/nginx.conf.j2
+++ b/oldnet/roles/nginx/templates/nginx.conf.j2
@@ -8,7 +8,7 @@ gzip_proxied any;
 
 log_format mtail '$server_name $remote_addr - $remote_user [$time_local] '
                  '"$request" $status $bytes_sent $request_time '
-                 '"$http_referer" "$http_user_agent"';
+                 '"$http_referer" "$http_user_agent" "$sent_http_content_type"';
 
 access_log off;
 error_log /var/log/nginx/error.log warn;

--- a/oldnet/roles/node_exporter/templates/nginx_node_exporter.conf.j2
+++ b/oldnet/roles/node_exporter/templates/nginx_node_exporter.conf.j2
@@ -16,3 +16,22 @@ server {
         proxy_set_header Host $host;
     }
 }
+
+server {
+    server_name mtail.local;
+    access_log /var/log/nginx/access.log mtail;
+    listen [{{ cjdns_identities[inventory_hostname].ipv6 }}]:3903;
+
+    location / {
+{% for hostname in cjdns_identities.keys() %}
+        allow {{ cjdns_identities[hostname].ipv6 }};
+{% endfor %}
+{% for addr in metrics_allowlist %}
+        allow {{ addr }};
+{% endfor %}
+        allow ::1;
+        deny all;
+        proxy_pass http://127.0.0.1:3903;
+        proxy_set_header Host $host;
+    }
+}

--- a/oldnet/roles/node_exporter/templates/nginx_node_exporter.conf.j2
+++ b/oldnet/roles/node_exporter/templates/nginx_node_exporter.conf.j2
@@ -1,5 +1,6 @@
 server {
-    server_name host.ipfs.local;
+    server_name node_exporter.local;
+    access_log /var/log/nginx/access.log mtail;
     listen [{{ cjdns_identities[inventory_hostname].ipv6 }}]:9100;
 
     location / {
@@ -14,7 +15,4 @@ server {
         proxy_pass http://127.0.0.1:9100;
         proxy_set_header Host $host;
     }
-
-    access_log /var/log/nginx/gateway.access.log mtail;
-    error_log /var/log/nginx/gateway.error.log;
 }

--- a/solarnet/env.sh
+++ b/solarnet/env.sh
@@ -6,7 +6,7 @@ provsn_groups=()
 all_ssh_options="-o ConnectTimeout=5"
 all_omit_build=(secrets/ipfs)
 
-baseunits=(base docker)
+baseunits=(base docker mtail)
 gatewayunits=(ipfs ipfs/multireq secrets/ipfs)
 
 spacerock_ssh="root@46.101.117.27"

--- a/solarnet/mtail/Dockerfile
+++ b/solarnet/mtail/Dockerfile
@@ -1,0 +1,26 @@
+FROM alpine:3.3
+MAINTAINER Lars Gierth <lgierth@ipfs.io>
+
+EXPOSE 3903
+
+ENV GO_VERSION 1.5.3-r0
+ENV GOPATH     /go
+ENV PATH       /go/bin:$PATH
+ENV SRC_PATH   /go/src/github.com/google/mtail
+ENV PROGS_PATH /mtail/progs
+ENV LOGS_PATH  /mtail/logs
+
+RUN apk add --update musl go=$GO_VERSION git bash make
+COPY . $SRC_PATH
+RUN mkdir -p $PROGS_PATH $LOGS_PATH \
+  && adduser -D -h /mtail -u 1000 mtail \
+  && chown mtail:mtail /mtail && chmod 755 /mtail \
+  && cd $SRC_PATH && rm -f .dep-stamp && make \
+  && mv `which mtail` /usr/local/bin/mtail \
+  && apk del --purge musl go git && rm -rf $GOPATH
+
+USER mtail
+VOLUME $PROGS_PATH
+VOLUME $LOGS_PATH
+WORKDIR $LOGS_PATH
+ENTRYPOINT ["/usr/local/bin/mtail", "-logtostderr", "-port", "3903", "-progs", "/mtail/progs", "-logs"]

--- a/solarnet/mtail/build.sh
+++ b/solarnet/mtail/build.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -e
+
+cat > docker.opts <<-EOF
+-d
+--name mtail
+--restart always
+-p 127.0.0.1:3903:3903
+--volume /opt/nginx/logs:/mtail/logs
+--volume /opt/mtail/progs:/mtail/progs
+--log-driver=json-file
+--log-opt max-size=100m
+--log-opt max-file=2
+mtail:$(lookup mtail_ref)
+access.log
+EOF

--- a/solarnet/mtail/env.sh
+++ b/solarnet/mtail/env.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+all_mtail_git='git://github.com/google/mtail'
+all_mtail_ref='20bb12dd503d6174e6e14b7a503571fd91411638'

--- a/solarnet/mtail/install.sh
+++ b/solarnet/mtail/install.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+set -e
+
+target="/opt/mtail"
+
+running=0
+rebuild=0
+restart=0
+
+ref=$(lookup mtail_ref)
+actual_ref=$(docker ps --format '{{.Image}}' | grep "mtail:" | cut -d':' -f2 || true)
+
+if [ ! -z "$actual_ref" ]; then
+  running=1
+fi
+
+if [ "$ref" != "$actual_ref" ]; then
+  restart=1
+fi
+
+if [ -z "$(docker images -q mtail:$ref)" ]; then
+  rebuild=1
+fi
+
+if [ ! -z "$(git diff "$target/Dockerfile" "Dockerfile" || echo "new")" ]; then
+  echo "$host: mtail dockerfile changed"
+  rebuild=1
+  restart=1
+fi
+
+if [ ! -z "$(git diff "$target/docker.opts" "docker.opts" || echo "new")" ]; then
+  echo "$host: mtail docker.opts changed"
+  restart=1
+fi
+
+if [ ! -z "$(git diff "$target/progs/nginx.mtail" "progs/nginx.mtail" || echo "new")" ]; then
+  echo "$host: mtail nginx.mtail changed"
+  restart=1
+fi
+
+if [ "rebuild$rebuild" == "rebuild1" ]; then
+  echo "$host: mtail rebuilding"
+  mkdir -p src/
+  git clone -q $(lookup mtail_git) "src/mtail"
+  git --work-tree="src/mtail" --git-dir="src/mtail/.git" reset -q --hard "$ref"
+  cp Dockerfile "src/mtail"
+  docker build -t "mtail:$ref" "src/mtail" #>/dev/null
+  echo "$host: mtail docker image changed"
+fi
+
+mkdir -p "$target/logs" "$target/progs"
+cp "progs/nginx.mtail" "$target/progs/nginx.mtail"
+
+if [ "restart$restart" == "restart1" ]; then
+  echo "$host: mtail restarting"
+  if [ "running$running" == "running1" ]; then
+    docker stop "mtail" >/dev/null || true
+    docker rm -f "mtail" >/dev/null || true
+  fi
+  docker run $(cat docker.opts) >/dev/null
+elif [ "running$running" == "running0" ]; then
+  echo "$host: mtail starting"
+  docker run $(cat docker.opts) >/dev/null
+fi
+
+# we only install these so we can get a diff and rebuild/restart if needed
+cp -a "docker.opts" "$target/docker.opts"
+cp -a "Dockerfile" "$target/Dockerfile"

--- a/solarnet/mtail/progs/nginx.mtail
+++ b/solarnet/mtail/progs/nginx.mtail
@@ -1,0 +1,25 @@
+counter http_requests_total by vhost, method, code
+counter http_request_duration_milliseconds_sum by vhost, method, code
+counter http_response_size_bytes_sum by vhost, method, code
+
+# log_format mtail '$server_name $remote_addr - $remote_user [$time_local] '
+#                  '"$request" $status $bytes_sent $request_time'
+#                  '"$http_referer" "$http_user_agent"';
+
+/^/ +
+/(?P<vhost>[0-9A-Za-z\.\-:]+) / +
+/(?P<remote_addr>[0-9A-Za-z\.\-:]+) / +
+/- / +
+/(?P<remote_user>[0-9A-Za-z\-]+) / +
+/(?P<time_local>\[\d{2}\/\w{3}\/\d{4}:\d{2}:\d{2}:\d{2} \+\d{4}\]) / +
+/"(?P<request_method>[A-Z]+) (?P<request_uri>\S+) (?P<http_version>HTTP\/[0-9\.]+)" / +
+/(?P<status>\d{3}) / +
+/(?P<bytes_sent>\d+) / +
+/(?P<request_seconds>\d+)\.(?P<request_milliseconds>\d+) / +
+/"(?P<http_referer>\S+)" / +
+/"(?P<http_user_agent>[[:print:]]+)"/ +
+/$/ {
+  http_requests_total[$vhost][tolower($request_method)][$status]++
+  http_request_duration_milliseconds_sum[$vhost][tolower($request_method)][$status] += $request_seconds * 1000 + $request_milliseconds
+  http_response_size_bytes_sum[$vhost][tolower($request_method)][$status] += $bytes_sent
+}

--- a/solarnet/mtail/progs/nginx.mtail
+++ b/solarnet/mtail/progs/nginx.mtail
@@ -1,6 +1,6 @@
-counter http_requests_total by vhost, method, code
-counter http_request_duration_milliseconds_sum by vhost, method, code
-counter http_response_size_bytes_sum by vhost, method, code
+counter http_requests_total by vhost, method, code, content_type
+counter http_request_duration_milliseconds_sum by vhost, method, code, content_type
+counter http_response_size_bytes_sum by vhost, method, code, content_type
 
 # log_format mtail '$server_name $remote_addr - $remote_user [$time_local] '
 #                  '"$request" $status $bytes_sent $request_time'
@@ -17,9 +17,10 @@ counter http_response_size_bytes_sum by vhost, method, code
 /(?P<bytes_sent>\d+) / +
 /(?P<request_seconds>\d+)\.(?P<request_milliseconds>\d+) / +
 /"(?P<http_referer>\S+)" / +
-/"(?P<http_user_agent>[[:print:]]+)"/ +
+/"(?P<http_user_agent>[[:print:]]+)" / +
+/"(?P<content_type>[^;]+)(;.*)?"/ +
 /$/ {
-  http_requests_total[$vhost][tolower($request_method)][$status]++
-  http_request_duration_milliseconds_sum[$vhost][tolower($request_method)][$status] += $request_seconds * 1000 + $request_milliseconds
-  http_response_size_bytes_sum[$vhost][tolower($request_method)][$status] += $bytes_sent
+  http_requests_total[$vhost][tolower($request_method)][$status][$content_type]++
+  http_request_duration_milliseconds_sum[$vhost][tolower($request_method)][$status][$content_type] += $request_seconds * 1000 + $request_milliseconds
+  http_response_size_bytes_sum[$vhost][tolower($request_method)][$status][$content_type] += $bytes_sent
 }


### PR DESCRIPTION
We introduce github.com/google/mtail for parsing nginx logs, and exposing request and response metrics to Prometheus.

- The build and install scripts are more verbose than they'll eventually have to be. The whole container build, start, restart thing hasn't been generalized yet.
- Oldnet is being touched for exposing mtail's HTTP interface, and wiring it with Prometheus. These two aspects haven't been migrated to Provsn yet.

TODO: have the gateway dashboard use the metrics scraped from mtail (`s/handler="gateway"/job="mtail"`)