### PR TITLE
metrics: accept new domain

### DIFF
--- a/oldnet/roles/metrics/templates/metrics.conf.j2
+++ b/oldnet/roles/metrics/templates/metrics.conf.j2
@@ -1,6 +1,6 @@
 server {
     listen [{{ cjdns_identities[inventory_hostname].ipv6 }}]:80;
-    server_name metrics.i.ipfs.io;
+    server_name metrics.i.ipfs.io metrics.ipfs.team ipfs.team;
 
 {% for hostname in cjdns_identities.keys() %}
     allow {{ cjdns_identities[hostname].ipv6 }};


### PR DESCRIPTION
Related to #101, this change adds support to copy `metrics.i.ipfs.io` records to `ipfs.team` or `metrics.ipfs.team` so it's not affected by the new hsts policy.