### PR TITLE
ipfs: run gateway and /ws bootstrapper

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -81,11 +81,11 @@ deimos_units=(${baseunits[@]})
 
 # digitalocean-ams3
 blueberry_ssh="root@178.62.215.134"
-blueberry_units=(${baseunits[@]} ${bootstrapunits[@]})
+blueberry_units=(${baseunits[@]} ${gatewayunits[@]})
 
 # digitalocean-nyc3
 strawberry_ssh="root@159.203.166.189"
-strawberry_units=(${baseunits[@]} ${bootstrapunits[@]})
+strawberry_units=(${baseunits[@]} ${gatewayunits[@]})
 
 jenkins_ssh="root@104.236.203.34"
 jenkins_units=(${baseunits[@]} ci/jenkins ssl)

--- a/ipfs/env.sh
+++ b/ipfs/env.sh
@@ -18,8 +18,8 @@ pollux_ipfs_ref=4e8015d74a945012b6f638439cdcb905f9a4971c
 nihal_ipfs_ref=4e8015d74a945012b6f638439cdcb905f9a4971c
 
 # dedicated bootstrap hosts
-strawberry_ipfs_ref=ed12bc5480860ad02b9d55d4d727f50a0baf6f91
-blueberry_ipfs_ref=ed12bc5480860ad02b9d55d4d727f50a0baf6f91
+strawberry_ipfs_ref=8291bd6ec6b9881a12ad6a137e78f5c3351b63cf
+blueberry_ipfs_ref=8291bd6ec6b9881a12ad6a137e78f5c3351b63cf
 
 all_ipfs_daemon_opts="--enable-gc"
 

--- a/ipfs/gateway/nginx.conf
+++ b/ipfs/gateway/nginx.conf
@@ -2,6 +2,20 @@ upstream gateway {
     server 127.0.0.1:8080;
 }
 
+upstream ws_bootstrap {
+    server 127.0.0.1:8081;
+}
+
+map \$http_upgrade \$upstream {
+    default gateway;
+    websocket ws_bootstrap;
+}
+
+map \$http_upgrade \$connection_upgrade {
+    default upgrade;
+    '' close;
+}
+
 server {
     server_name ipfs.io;
     access_log /var/log/nginx/access.log mtail;
@@ -96,9 +110,11 @@ server {
     }
 
     location / {
-        proxy_set_header Host \$host;
+        proxy_set_header Host \$host:80;
         proxy_set_header X-Ipfs-Gateway-Prefix "";
-        proxy_pass http://gateway;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection \$connection_upgrade;
+        proxy_pass http://\$upstream;
         proxy_pass_header Server;
         proxy_read_timeout 1800s;
     }


### PR DESCRIPTION
This proxies the upgraded connection to :8081, where the /ws listener listens. Runs ipfs/go-ipfs@8291bd6ec6b9881a12ad6a137e78f5c3351b63cf.

The nicer solution is mounting the WebsocketTransport on the gateway within go-ipfs.