### PR TITLE
gateway: separate ipfs.io website from ipfs.io gateway

### DIFF
--- a/ipfs/gateway/denylist.conf
+++ b/ipfs/gateway/denylist.conf
@@ -1,0 +1,53 @@
+error_page 451 /_errors/451.html;
+location /_errors {
+    root /usr/share/nginx/html;
+}
+
+# dmca takedown
+location ~ "^/ipns/Qmbk5dja9CqyrmymV6EdQLzvNo9zCkGyGQKYrL5ya5oHwu" {
+    return 451;
+}
+# dmca takedown
+location ~ "^/ipfs/QmTmMhRv2nh889JfYBWXdxSvNS6zWnh4QFo4Q2knV7Ei2B" {
+    return 451;
+}
+# copyright
+location ~ "^/ipfs/QmW1SUEcZaa1Npk4xr6Qz56LsupD7cpj3JtZN5jHgdtPH6" {
+    return 451;
+}
+# copyright
+location ~ "^/ipfs/QmXS9kAEBLntiDAKY8yjfhgBaDio5DnZUFngFTYRzVKJbB" {
+    return 451;
+}
+# copyright
+location ~ "^/ipfs/QmVktW6uo1mcqSiufH7fmExsmyC7dFx2GCYiEDmJLSatnD" {
+    return 451;
+}
+# copyright
+location ~ "^/ipfs/QmVBEScm197eQiqgUpstf9baFAaEnhQCgzHKiXnkCoED2c" {
+    return 451;
+}
+# copyright
+location ~ "^/ipfs/QmUSgfC3RsXKzKJuUNtpzDK2Wm4ehPxhQ1SxJMcgUqStxg" {
+    return 451;
+}
+# copyright
+location ~ "^/ipfs/QmfWQHVazH6so9p27z27rr8TJSdBFGpH7hunDcaZ1EAQ2c" {
+    return 451;
+}
+# copyright
+location ~ "^/ipfs/QmcvyefkqQX3PpjpY5L8B2yMd47XrVwAipr6cxUt2zvYU8" {
+    return 451;
+}
+# not a dmca takedown -- there be bad bits
+location ~ "^/ipfs/QmY7KEmJKpx7bNDQ2WfDJp2zdsvX1ATZKWd4AXAhDLCaBM" {
+    return 451;
+}
+# dmca takedown
+location ~ "^/ipfs/QmZhpyoqRocNsZ6AWofbVcigiANcgnpUBbokB9qLipsGkU" {
+    return 451;
+}
+# dmca takedown
+location ~ "^/ipfs/QmPop8VHh8r8zS1kg7VzZGMXwYGx1e3f81WERvMhDesfao" {
+    return 451;
+}

--- a/ipfs/gateway/install.sh
+++ b/ipfs/gateway/install.sh
@@ -31,12 +31,19 @@ if [ ! -z "$(diff -Naur "$target/certs/dhparam.pem" "out/dhparam.pem")" ]; then
   reload=1
 fi
 
+if [ ! -z "$(diff -Naur "$target/conf.d/gateway/denylist.conf" "denylist.conf")" ]; then
+  echo "ipfs/gateway denylist changed"
+  reload=1
+fi
+
 cp "out/6-ipfs-gateway.conf" "$target/conf.d/6-ipfs-gateway.conf"
 cp "out/ipfs.io.crt" "$target/certs/ipfs.io.crt"
 cp "out/ipfs.io.key" "$target/certs/ipfs.io.key"
 cp "out/ipfs.io.trustchain.crt" "$target/certs/ipfs.io.trustchain.crt"
 # TODO: rename to ipfs.io.dhparam.pem
 cp "out/dhparam.pem" "$target/certs/dhparam.pem"
+mkdir -p "$target/conf.d/gateway"
+cp "denylist.conf" "$target/conf.d/gateway/denylist.conf"
 
 if [ "reload$reload" == "reload1" ]; then
   echo "ipfs/gateway nginx reloading"

--- a/ipfs/gateway/nginx.conf
+++ b/ipfs/gateway/nginx.conf
@@ -22,8 +22,11 @@ map \$http_upgrade \$connection_upgrade {
     '' close;
 }
 
+# TODO set proper port in Host headers,
+#      we're just working around libp2p/go-ws-transport#8 for now.
+
 server {
-    server_name ipfs.io;
+    server_name gateway.ipfs.io;
     access_log /var/log/nginx/access.log mtail;
 
     listen 80 default_server;
@@ -37,91 +40,59 @@ server {
     ssl_dhparam /etc/nginx/certs/dhparam.pem;
     ssl_trusted_certificate /etc/nginx/certs/ipfs.io.trustchain.crt;
 
+    include conf.d/gateway/denylist.conf;
+
+    proxy_set_header Upgrade \$http_upgrade;
+    proxy_set_header Connection \$connection_upgrade;
+    proxy_pass_header Server;
+    proxy_read_timeout 1800s;
+
+    location / {
+        proxy_set_header Host \$host:80;
+        proxy_set_header X-Ipfs-Gateway-Prefix "";
+        proxy_pass http://\$upstream;
+    }
+}
+
+server {
+    server_name ipfs.io;
+    access_log /var/log/nginx/access.log mtail;
+
+    listen 80;
+    listen [::]:80;
+    listen [$(var cjdns_ipv6)]:80;
+
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    ssl_certificate /etc/nginx/certs/ipfs.io.crt;
+    ssl_certificate_key /etc/nginx/certs/ipfs.io.key;
+    ssl_dhparam /etc/nginx/certs/dhparam.pem;
+    ssl_trusted_certificate /etc/nginx/certs/ipfs.io.trustchain.crt;
+
+    include conf.d/gateway/denylist.conf;
+
+    proxy_set_header Upgrade \$http_upgrade;
+    proxy_set_header Connection \$connection_upgrade;
+    proxy_pass_header Server;
+    proxy_read_timeout 1800s;
+
     location /blog/ {
         rewrite "^/blog(/.*)$" \$1 break;
-        proxy_set_header Host blog.ipfs.io;
+        proxy_set_header Host blog.ipfs.io:80;
         proxy_set_header X-Ipfs-Gateway-Prefix /blog;
-        proxy_pass http://gateway;
-        proxy_read_timeout 1800s;
+        proxy_pass http://\$upstream;
     }
 
     location /refs/ {
         rewrite "^/refs(/.*)$" \$1 break;
-        proxy_set_header Host refs.ipfs.io;
+        proxy_set_header Host refs.ipfs.io:80;
         proxy_set_header X-Ipfs-Gateway-Prefix /refs;
-        proxy_pass http://gateway;
-        proxy_pass_header Server;
-        proxy_read_timeout 1800s;
-    }
-
-    error_page 451 /_errors/451.html;
-    location /_errors {
-        root /usr/share/nginx/html;
-    }
-    # dmca takedown
-    location ~ "^/ipns/Qmbk5dja9CqyrmymV6EdQLzvNo9zCkGyGQKYrL5ya5oHwu" {
-        return 451;
-    }
-    # dmca takedown
-    location ~ "^/ipfs/QmTmMhRv2nh889JfYBWXdxSvNS6zWnh4QFo4Q2knV7Ei2B" {
-        return 451;
-    }
-    # copyright
-    location ~ "^/ipfs/QmW1SUEcZaa1Npk4xr6Qz56LsupD7cpj3JtZN5jHgdtPH6" {
-        return 451;
-    }
-    # copyright
-    location ~ "^/ipfs/QmXS9kAEBLntiDAKY8yjfhgBaDio5DnZUFngFTYRzVKJbB" {
-        return 451;
-    }
-    # copyright
-    location ~ "^/ipfs/QmVktW6uo1mcqSiufH7fmExsmyC7dFx2GCYiEDmJLSatnD" {
-        return 451;
-    }
-    # copyright
-    location ~ "^/ipfs/QmVBEScm197eQiqgUpstf9baFAaEnhQCgzHKiXnkCoED2c" {
-        return 451;
-    }
-    # copyright
-    location ~ "^/ipfs/QmUSgfC3RsXKzKJuUNtpzDK2Wm4ehPxhQ1SxJMcgUqStxg" {
-        return 451;
-    }
-    # copyright
-    location ~ "^/ipfs/QmfWQHVazH6so9p27z27rr8TJSdBFGpH7hunDcaZ1EAQ2c" {
-        return 451;
-    }
-    # copyright
-    location ~ "^/ipfs/QmcvyefkqQX3PpjpY5L8B2yMd47XrVwAipr6cxUt2zvYU8" {
-        return 451;
-    }
-    # not a dmca takedown -- there be bad bits
-    location ~ "^/ipfs/QmY7KEmJKpx7bNDQ2WfDJp2zdsvX1ATZKWd4AXAhDLCaBM" {
-        return 451;
-    }
-    # dmca takedown
-    location ~ "^/ipfs/QmZhpyoqRocNsZ6AWofbVcigiANcgnpUBbokB9qLipsGkU" {
-        return 451;
-    }
-    # dmca takedown
-    location ~ "^/ipfs/QmPop8VHh8r8zS1kg7VzZGMXwYGx1e3f81WERvMhDesfao" {
-        return 451;
-    }
-
-    location ~ "^/(ipfs|ipns|api)(/|$)" {
-        proxy_set_header Host "";
-        proxy_set_header X-Ipfs-Gateway-Prefix "";
-        proxy_pass http://gateway;
-        proxy_pass_header Server;
-        proxy_read_timeout 1800s;
+        proxy_pass http://\$upstream;
     }
 
     location / {
         proxy_set_header Host \$host:80;
         proxy_set_header X-Ipfs-Gateway-Prefix "";
-        proxy_set_header Upgrade \$http_upgrade;
-        proxy_set_header Connection \$connection_upgrade;
         proxy_pass http://\$upstream;
-        proxy_pass_header Server;
-        proxy_read_timeout 1800s;
     }
 }


### PR DESCRIPTION
The /blog and /refs rewrites were applying to all IPNS websites too.
@daviddias pinged me about daviddias.me/blog returning ipfs.io/blog -- ooops!

This commit breaks up the gateway vhost into gateway and website.
Had it deployed for a week or so already, sorry about that :S

It also moves the denylist rules into their own file.

Closes #224