### PR TITLE
Fix dnslink.sh issue when creating new TXT record

### DIFF
--- a/scripts/dnslink.sh
+++ b/scripts/dnslink.sh
@@ -36,7 +36,7 @@ if [ -z "$record_id" ]; then
     -H "X-DNSimple-Domain-Token: $DNSIMPLE_TOKEN" \
     -H "Accept: application/json" \
     -H "Content-Type: application/json" \
-    -d "{\"record\":{ \"name\":\"$RECORD_NAME\", \"type\":\"TXT\", \"content\":\"dnslink=/ipfs/$HASH\", \"ttl\":\"$RECORD_TTL\" }}" \
+    -d "{\"record\":{ \"name\":\"$RECORD_NAME\", \"record_type\":\"TXT\", \"content\":\"dnslink=/ipfs/$HASH\", \"ttl\":\"$RECORD_TTL\" }}" \
     | jq -r '.record' \
   && printf "\\nIt looks like we're good: https://ipfs.io/ipns/$ZONE\\n"
 else


### PR DESCRIPTION
I had to tweak `dnslink.sh` when testing it out on a new domain to use the property name `record_type` instead of `type` to get it to create a new TXT record where none previously exists. See https://developer.dnsimple.com/v1/domains/records/#create