### PR TITLE
Add ipfs-cluster unit

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -19,6 +19,7 @@ baseunits+=(mtail metrics/node_exporter metrics/blackbox_exporter)
 gatewayunits=(ipfs ipfs/gateway ipfs/pages ssl)
 storageunits=(ipfs)
 bootstrapunits=(ipfs)
+ipfsclusterunits=(ipfs-cluster)
 metricsunits=(metrics/grafana metrics/prometheus)
 
 # Units listed in `omit_build` will not be copied into each host's .build dir.
@@ -30,52 +31,52 @@ all_omit_build=(secrets)
 # digitalocean-sfo1
 pluto_ssh="root@pluto.i.ipfs.team"
 pluto_ipv4_address="104.236.179.241"
-pluto_units=(${baseunits[@]} ${gatewayunits[@]})
+pluto_units=(${baseunits[@]} ${gatewayunits[@]} ${ipfsclusterunits[@]})
 
 # digitalocean-sfo1
 neptune_ssh="root@neptune.i.ipfs.team"
 neptune_ipv4_address="104.236.176.52"
-neptune_units=(${baseunits[@]} ${gatewayunits[@]})
+neptune_units=(${baseunits[@]} ${gatewayunits[@]} ${ipfsclusterunits[@]})
 
 # digitalocean-nyc2
 uranus_ssh="root@uranus.i.ipfs.team"
 uranus_ipv4_address="162.243.248.213"
-uranus_units=(${baseunits[@]} ${gatewayunits[@]})
+uranus_units=(${baseunits[@]} ${gatewayunits[@]} ${ipfsclusterunits[@]})
 
 # digitalocean-sgp1
 saturn_ssh="root@saturn.i.ipfs.team"
 saturn_ipv4_address="128.199.219.111"
-saturn_units=(${baseunits[@]} ${gatewayunits[@]})
+saturn_units=(${baseunits[@]} ${gatewayunits[@]} ${ipfsclusterunits[@]})
 
 # digitalocean-sfo1
 jupiter_ssh="root@jupiter.i.ipfs.team"
 jupiter_ipv4_address="104.236.151.122"
-jupiter_units=(${baseunits[@]} ${gatewayunits[@]})
+jupiter_units=(${baseunits[@]} ${gatewayunits[@]} ${ipfsclusterunits[@]})
 
 # digitalocean-nyc3
 venus_ssh="root@venus.i.ipfs.team"
 venus_ipv4_address="104.236.76.40"
-venus_units=(${baseunits[@]} ${gatewayunits[@]})
+venus_units=(${baseunits[@]} ${gatewayunits[@]} ${ipfsclusterunits[@]})
 
 # digitalocean-ams2
 earth_ssh="root@earth.i.ipfs.team"
 earth_ipv4_address="178.62.158.247"
-earth_units=(${baseunits[@]} ${gatewayunits[@]})
+earth_units=(${baseunits[@]} ${gatewayunits[@]} ${ipfsclusterunits[@]})
 
 # digitalocean-lon1
 mercury_ssh="root@mercury.i.ipfs.team"
 mercury_ipv4_address="178.62.61.185"
-mercury_units=(${baseunits[@]} ${gatewayunits[@]})
+mercury_units=(${baseunits[@]} ${gatewayunits[@]} ${ipfsclusterunits[@]})
 
 # ovh
 scrappy_ssh="root@scrappy.i.ipfs.team"
 scrappy_ipv4_address="217.182.195.23"
-scrappy_units=(${baseunits[@]} ${gatewayunits[@]})
+scrappy_units=(${baseunits[@]} ${gatewayunits[@]} ${ipfsclusterunits[@]})
 
 # ovh
 chappy_ssh="root@chappy.i.ipfs.team"
 chappy_ipv4_address="147.135.130.181"
-chappy_units=(${baseunits[@]} ${gatewayunits[@]})
+chappy_units=(${baseunits[@]} ${gatewayunits[@]} ${ipfsclusterunits[@]})
 
 # hetzner-nuremberg
 pollux_ssh="root@pollux.i.ipfs.team"

--- a/ipfs-cluster/README.md
+++ b/ipfs-cluster/README.md
@@ -1,0 +1,5 @@
+## Unit - ipfs-cluster
+
+The ipfs-cluster unit, responsible for running ipfs-cluster peers.
+
+It starts ipfs-cluster in a docker container.

--- a/ipfs-cluster/build.sh
+++ b/ipfs-cluster/build.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+
+mkdir -p out/
+provsn_template "service.json.tpl" "out/ipfs-cluster_service.json"
+
+cat > out/ipfs-cluster.opts <<-EOF
+-d
+--name ipfs-cluster
+--restart always
+--net host
+--env IPFS_CLUSTER_PATH=/data/ipfs-cluster
+--log-driver=json-file
+--log-opt max-size=100m
+--log-opt max-file=2
+-v $(lookup ipfs_cluster_data):/data/ipfs-cluster
+ipfs-cluster:$(lookup ipfs_cluster_ref | head -c 7)
+EOF

--- a/ipfs-cluster/env.sh
+++ b/ipfs-cluster/env.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 all_ipfs_cluster_git=git://github.com/ipfs/ipfs-cluster
-all_ipfs_cluster_ref="11a8926236afe119ab78bc583cd8b272e762d86e"
+all_ipfs_cluster_ref="e824aea55eea120da7f8f3ba7da3ffe11a053287"
 
 # Identities of the nodes. The private keys are hidden away in the secrets unit.
 pluto_ipfs_cluster_peerid="QmSiW1LpXRzbkuhjSABTJBJd9zb5vckVofbTFLjH5fmrM5"

--- a/ipfs-cluster/env.sh
+++ b/ipfs-cluster/env.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+all_ipfs_cluster_git=git://github.com/ipfs/ipfs-cluster
+all_ipfs_cluster_ref="11a8926236afe119ab78bc583cd8b272e762d86e"
+
+# Identities of the nodes. The private keys are hidden away in the secrets unit.
+pluto_ipfs_cluster_peerid="QmSiW1LpXRzbkuhjSABTJBJd9zb5vckVofbTFLjH5fmrM5"
+neptune_ipfs_cluster_peerid="QmQBriDc5ZNAHdYzC9gAZ17s1eJvenp5SUzHnZMv65pnJH"
+uranus_ipfs_cluster_peerid="QmQEn69dRXLENMaV33f2MRAqNg4u1GwzjisWr4ewQ4B974"
+saturn_ipfs_cluster_peerid="QmNWGCZe8StGiJ6G4HKqmB3YkMVPoQvbPqE6yo8paQddVP"
+jupiter_ipfs_cluster_peerid="QmTVCTKnCueMz95ifXC81jQZyX9e43cDT9AXnGcjd71XoU"
+venus_ipfs_cluster_peerid="QmQfpaSGNkXtMHD3UyLUUWcaKquT4hA1h42wcPxZXtXdeT"
+earth_ipfs_cluster_peerid="QmWZEJm76A7v8qBXKQcFKcGFA982Qwhzz6zZMakRMoVWZo"
+mercury_ipfs_cluster_peerid="QmUpZtr7MhrkZCZRPjG3xoL4ocpy1v1JNuvnhnfv5mGhYs"
+scrappy_ipfs_cluster_peerid="QmRjdKMdQbvhjiXVncoC9pdouFoJcxRxXy78Ucd2XdnoSS"
+chappy_ipfs_cluster_peerid="QmXYzjACnh4yZPYcm93TJLcFLh4MdBJCN3tK7uVMnLCmPQ"
+
+
+# Historical location, TODO: move to /mnt/data/ipfs
+all_ipfs_cluster_data=/ipfs/ipfs-cluster

--- a/ipfs-cluster/install.sh
+++ b/ipfs-cluster/install.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+set -e
+
+target="/opt/ipfs-cluster"
+data=$(lookup ipfs_cluster_data)
+
+rebuild=0
+restart=0
+
+ref=$(lookup ipfs_cluster_ref | head -c 7)
+actual_ref=$(docker ps --format '{{.Image}}' | grep "ipfs-cluster:" | cut -d':' -f2 || true)
+
+if [ -z "$(docker ps -f status=running | grep "ipfs-cluster:" || true)" ]; then
+  echo "daemon not running"
+  restart=1
+fi
+
+if [ "ref$ref" != "ref$actual_ref" ]; then
+  echo "ref changed from $actual_ref to $ref"
+  restart=1
+fi
+
+if [ -z "$(docker images -q ipfs-cluster:$ref)" ]; then
+  echo "docker image doesn't exist yet"
+  rebuild=1
+fi
+
+if [ ! -z "$(git diff "$target/docker.opts" "out/ipfs-cluster.opts" || echo "new")" ]; then
+  echo "ipfs-cluster docker.opts changed"
+  restart=1
+fi
+
+if [ ! -z "$(git diff "$target/service.json" "out/ipfs-cluster_service.json" || echo "new")" ]; then
+  echo "ipfs-cluster config changed"
+  restart=1
+fi
+
+if [ "rebuild$rebuild" == "rebuild1" ]; then
+  echo "ipfs-cluster rebuilding"
+  [ -d "$target/src/.git" ] || git clone -q $(lookup ipfs_cluster_git) "$target/src"
+  git --git-dir="$target/src/.git" remote set-url origin $(lookup ipfs_cluster_git)
+  git --git-dir="$target/src/.git" remote prune origin >/dev/null
+  git --git-dir="$target/src/.git" prune
+  git --git-dir="$target/src/.git" gc --quiet
+  git --git-dir="$target/src/.git" fetch -q --all
+  git --git-dir="$target/src/.git" --work-tree="$target/src" reset -q --hard "$ref"
+  docker build -t "ipfs-cluster:$ref" "$target/src" >/dev/null
+  echo "ipfs-cluster docker image changed"
+  restart=1
+fi
+
+if [ ! -f "$data/service.json" ]; then
+  mkdir -p "$data"
+  chown -R 1000:users "$data"
+  restart=1
+fi
+
+cp "out/ipfs-cluster_service.json" "$data/service.json"
+chown 1000:users "$data/service.json"
+
+if [ "restart$restart" == "restart1" ]; then
+  echo "ipfs-cluster (re)starting"
+  docker stop "ipfs-cluster" 2>&1 >/dev/null || true
+  docker rm -f "ipfs-cluster" 2>&1 >/dev/null || true
+  docker run $(cat out/ipfs-cluster.opts) >/dev/null
+fi
+
+# we only install these so we can get a diff and rebuild/restart if needed
+mkdir -p "$target"
+cp -a "out/ipfs-cluster_service.json" "$target/service.json"
+cp -a "out/ipfs-cluster.opts" "$target/docker.opts"
+rm -f "$target/Dockerfile"
+

--- a/ipfs-cluster/install.sh
+++ b/ipfs-cluster/install.sh
@@ -21,7 +21,7 @@ if [ "ref$ref" != "ref$actual_ref" ]; then
   restart=1
 fi
 
-if [ -z "$(docker images -q ipfs-cluster:$ref)" ]; then
+if [ -z "$(docker images -q ipfs-cluster:${ref})" ]; then
   echo "docker image doesn't exist yet"
   rebuild=1
 fi
@@ -38,7 +38,7 @@ fi
 
 if [ "rebuild$rebuild" == "rebuild1" ]; then
   echo "ipfs-cluster rebuilding"
-  [ -d "$target/src/.git" ] || git clone -q $(lookup ipfs_cluster_git) "$target/src"
+  [ -d "$target/src/.git" ] || git clone -q "$(lookup ipfs_cluster_git)" "$target/src"
   git --git-dir="$target/src/.git" remote set-url origin $(lookup ipfs_cluster_git)
   git --git-dir="$target/src/.git" remote prune origin >/dev/null
   git --git-dir="$target/src/.git" prune
@@ -61,8 +61,8 @@ chown 1000:users "$data/service.json"
 
 if [ "restart$restart" == "restart1" ]; then
   echo "ipfs-cluster (re)starting"
-  docker stop "ipfs-cluster" 2>&1 >/dev/null || true
-  docker rm -f "ipfs-cluster" 2>&1 >/dev/null || true
+  docker stop "ipfs-cluster" >/dev/null 2>&1 || true
+  docker rm -f "ipfs-cluster" >/dev/null 2>&1 || true
   docker run $(cat out/ipfs-cluster.opts) >/dev/null
 fi
 

--- a/ipfs-cluster/service.json.tpl
+++ b/ipfs-cluster/service.json.tpl
@@ -1,0 +1,84 @@
+{
+  "cluster": {
+    "id": "$(var ipfs_cluster_peerid)",
+    "private_key": "$(var ipfs_cluster_private_key)",
+    "secret": "$(var ipfs_cluster_secret)",
+    "peers": [
+      "/dns4/pluto.i.ipfs.team/tcp/9096/ipfs/QmSiW1LpXRzbkuhjSABTJBJd9zb5vckVofbTFLjH5fmrM5",
+      "/dns4/neptune.i.ipfs.team/tcp/9096/ipfs/QmQBriDc5ZNAHdYzC9gAZ17s1eJvenp5SUzHnZMv65pnJH",
+      "/dns4/uranus.i.ipfs.team/tcp/9096/ipfs/QmQEn69dRXLENMaV33f2MRAqNg4u1GwzjisWr4ewQ4B974",
+      "/dns4/saturn.i.ipfs.team/tcp/9096/ipfs/QmNWGCZe8StGiJ6G4HKqmB3YkMVPoQvbPqE6yo8paQddVP",
+      "/dns4/jupiter.i.ipfs.team/tcp/9096/ipfs/QmTVCTKnCueMz95ifXC81jQZyX9e43cDT9AXnGcjd71XoU",
+      "/dns4/venus.i.ipfs.team/tcp/9096/ipfs/QmQfpaSGNkXtMHD3UyLUUWcaKquT4hA1h42wcPxZXtXdeT",
+      "/dns4/earth.i.ipfs.team/tcp/9096/ipfs/QmWZEJm76A7v8qBXKQcFKcGFA982Qwhzz6zZMakRMoVWZo",
+      "/dns4/mercury.i.ipfs.team/tcp/9096/ipfs/QmUpZtr7MhrkZCZRPjG3xoL4ocpy1v1JNuvnhnfv5mGhYs",
+      "/dns4/scrappy.i.ipfs.team/tcp/9096/ipfs/QmRjdKMdQbvhjiXVncoC9pdouFoJcxRxXy78Ucd2XdnoSS",
+      "/dns4/chappy.i.ipfs.team/tcp/9096/ipfs/QmXYzjACnh4yZPYcm93TJLcFLh4MdBJCN3tK7uVMnLCmPQ"
+    ],
+    "bootstrap": [],
+    "leave_on_shutdown": false,
+    "listen_multiaddress": "/ip4/0.0.0.0/tcp/9096",
+    "state_sync_interval": "2m0s",
+    "ipfs_sync_interval": "5m",
+    "replication_factor": -1,
+    "monitor_ping_interval": "45s"
+  },
+  "consensus": {
+    "raft": {
+      "wait_for_leader_timeout": "25s",
+      "network_timeout": "10s",
+      "commit_retries": 1,
+      "commit_retry_delay": "500ms",
+      "heartbeat_timeout": "2s",
+      "election_timeout": "2s",
+      "commit_timeout": "100ms",
+      "max_append_entries": 256,
+      "trailing_logs": 10240,
+      "snapshot_interval": "5m0s",
+      "snapshot_threshold": 8192,
+      "leader_lease_timeout": "1000ms"
+    }
+  },
+  "api": {
+    "restapi": {
+      "listen_multiaddress": "/ip4/127.0.0.1/tcp/9094",
+      "read_timeout": "60s",
+      "read_header_timeout": "5s",
+      "write_timeout": "1m0s",
+      "idle_timeout": "2m0s",
+      "basic_auth_credentials": null
+    }
+  },
+  "ipfs_connector": {
+    "ipfshttp": {
+      "proxy_listen_multiaddress": "/ip4/127.0.0.1/tcp/9095",
+      "node_multiaddress": "/ip4/127.0.0.1/tcp/5001",
+      "connect_swarms_delay": "30s",
+      "proxy_read_timeout": "10m0s",
+      "proxy_read_header_timeout": "5s",
+      "proxy_write_timeout": "10m0s",
+      "proxy_idle_timeout": "1m0s"
+    }
+  },
+  "pin_tracker": {
+    "maptracker": {
+      "pinning_timeout": "1h0m0s",
+      "unpinning_timeout": "5m0s",
+      "max_pin_queue_size": 4096
+    }
+  },
+  "monitor": {
+    "monbasic": {
+      "check_interval": "180s"
+    }
+  },
+  "informer": {
+    "disk": {
+      "metric_ttl": "120s",
+      "metric_type": "freespace"
+    },
+    "numpin": {
+      "metric_ttl": "10s"
+    }
+  }
+}

--- a/ipfs/env.sh
+++ b/ipfs/env.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 all_ipfs_git=git://github.com/ipfs/go-ipfs
-all_ipfs_ref="5d23fd7c4584f802eae853f5b3c1b575cdc2eb04"
+all_ipfs_ref="a81025f89185942c2e40168bec55dee581f0da25"
 
 # storage hosts, coordinate ipfs deploys with storage users (e.g. @davidar, @substack)
 biham_ipfs_ref=f1af17c411cf1e96c27cacdd8468f364174039d6 # exp/sync-concurrency (@whyrusleeping)


### PR DESCRIPTION
The changes in this commit allow provsn to deploy an ipfs-cluster
container along with the ipfs-one in the 10 nodes that ipfs-bot uses.