### PR TITLE
cluster: Increase disk informer interval

### DIFF
--- a/ipfs-cluster/service.json.tpl
+++ b/ipfs-cluster/service.json.tpl
@@ -74,7 +74,7 @@
   },
   "informer": {
     "disk": {
-      "metric_ttl": "120s",
+      "metric_ttl": "1200s",
       "metric_type": "freespace"
     },
     "numpin": {


### PR DESCRIPTION
This will make cluster call repo/stat 10x times less. It's deployed already.