### PR TITLE
Add jenkins scraping to prometheus

### DIFF
--- a/metrics/prometheus/prometheus.yml.tpl
+++ b/metrics/prometheus/prometheus.yml.tpl
@@ -180,3 +180,13 @@ done)
     static_configs:
       - targets:
         - $(var prometheus_libp2pstats_target)
+
+
+  - job_name: 'jenkins'
+    scheme: https
+    metrics_path: '/prometheus'
+    honor_labels: false
+    static_configs:
+      - targets: ['ci.ipfs.team']
+        labels:
+          group: jenkins


### PR DESCRIPTION
Currently unprotected /prometheus endpoint on jenkins, but AFAIK, there is no secret values there or any actions that could be performed via the endpoint.